### PR TITLE
Fix critical bugs, add tests, complete spec compliance

### DIFF
--- a/.github/workflows/discover_manual_assist.yml
+++ b/.github/workflows/discover_manual_assist.yml
@@ -5,3 +5,23 @@ on:
     - cron: '5 4 * * 1'
 permissions:
   contents: write
+jobs:
+  manual-assist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -r requirements.txt
+      - run: |
+          echo "Manual-assist discovery sources (Google Scholar, Dimensions, BASE)"
+          echo "require human-assisted review. This workflow logs a reminder."
+          echo ""
+          echo "To add papers from these sources:"
+          echo "  1. Search manually on Google Scholar / Dimensions / BASE"
+          echo "  2. Add rows to data/discovery_candidates.csv"
+          echo "  3. Run the quality gate: python -m alex.cli score"
+          echo ""
+          echo "Sources requiring manual assist:"
+          python -c "import json; print(json.dumps(json.load(open('config/manual_assist_sources.json')), indent=2))"

--- a/.github/workflows/harvest_all.yml
+++ b/.github/workflows/harvest_all.yml
@@ -5,3 +5,21 @@ on:
     - cron: '31 3 * * 0'
 permissions:
   contents: write
+jobs:
+  harvest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -r requirements.txt
+      - env:
+          HARVEST_MAILTO: ${{ secrets.HARVEST_MAILTO }}
+        run: python -m alex.cli harvest
+      - run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/accepted_harvested.csv
+          git diff --cached --quiet || git commit -m "Harvest all metadata"
+          git push

--- a/.github/workflows/rebuild_site.yml
+++ b/.github/workflows/rebuild_site.yml
@@ -1,3 +1,21 @@
 name: Rebuild site assets
 on:
   workflow_dispatch:
+permissions:
+  contents: write
+jobs:
+  rebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -r requirements.txt
+      - run: python -m alex.cli publish
+      - run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/osint_cyber_papers.csv data/papers.json
+          git diff --cached --quiet || git commit -m "Rebuild site assets"
+          git push

--- a/.github/workflows/tag_new_papers.yml
+++ b/.github/workflows/tag_new_papers.yml
@@ -1,3 +1,24 @@
 name: Tag new papers with LLM classification
 on:
   workflow_dispatch:
+permissions:
+  contents: write
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -r requirements.txt
+      - env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_MODEL: ${{ vars.OPENAI_MODEL || 'gpt-4o-mini' }}
+        run: python -m alex.cli classify
+      - run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/accepted_classified.csv
+          git diff --cached --quiet || git commit -m "Tag new papers via LLM classification"
+          git push

--- a/alex/cli.py
+++ b/alex/cli.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 import argparse
+import logging
 from alex.pipelines import discovery, citation_chain, quality_gate, harvest, classify, publish
 
+
 def main():
-    ap = argparse.ArgumentParser()
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    ap = argparse.ArgumentParser(prog="alex", description="OSINT research corpus pipeline")
     ap.add_argument("command", choices=["discover", "chain", "score", "harvest", "classify", "publish"])
     args = ap.parse_args()
     {
@@ -14,6 +21,7 @@ def main():
         "classify": classify.run,
         "publish": publish.run,
     }[args.command]()
+
 
 if __name__ == "__main__":
     main()

--- a/alex/connectors/arxiv.py
+++ b/alex/connectors/arxiv.py
@@ -1,13 +1,22 @@
 from __future__ import annotations
+import logging
 import xml.etree.ElementTree as ET
-import requests
+from alex.utils.http import HttpClient
+
+logger = logging.getLogger(__name__)
 
 ARXIV = "http://export.arxiv.org/api/query"
 
-def search(query: str, max_results: int = 25) -> list[dict]:
+
+def search(client: HttpClient, query: str, max_results: int = 25) -> list[dict]:
     params = {"search_query": f"all:{query}", "start": 0, "max_results": max_results}
-    r = requests.get(ARXIV, params=params, timeout=30)
-    if r.status_code != 200:
+    try:
+        r = client.session.get(ARXIV, params=params, timeout=30)
+        if r.status_code != 200:
+            logger.warning("arXiv returned status %d for query: %s", r.status_code, query)
+            return []
+    except Exception as exc:
+        logger.warning("arXiv request failed: %s", exc)
         return []
     root = ET.fromstring(r.text)
     ns = {"a": "http://www.w3.org/2005/Atom"}
@@ -20,6 +29,6 @@ def search(query: str, max_results: int = 25) -> list[dict]:
             "authors": authors,
             "year": (entry.findtext("a:published", default="", namespaces=ns) or "")[:4],
             "source_url": entry.findtext("a:id", default="", namespaces=ns),
-            "discovery_source": "arXiv"
+            "discovery_source": "arXiv",
         })
     return out

--- a/alex/connectors/openalex.py
+++ b/alex/connectors/openalex.py
@@ -29,3 +29,24 @@ def cited_by_api_url(work: dict[str, Any]) -> str:
 def fetch_cited_by(client: HttpClient, cited_by_url: str) -> list[dict[str, Any]]:
     data = client.get_json(cited_by_url)
     return (data or {}).get("results", [])
+
+
+def venue_name(work: dict[str, Any]) -> str:
+    return ((work.get("primary_location") or {}).get("source") or {}).get("display_name", "")
+
+
+def doi(work: dict[str, Any]) -> str:
+    raw = (work.get("ids") or {}).get("doi", "") or ""
+    return raw.replace("https://doi.org/", "")
+
+
+def landing_url(work: dict[str, Any]) -> str:
+    return (work.get("primary_location") or {}).get("landing_page_url", "")
+
+
+def author_names(work: dict[str, Any]) -> str:
+    return "; ".join(
+        (a.get("author") or {}).get("display_name", "")
+        for a in (work.get("authorships") or [])
+        if (a.get("author") or {}).get("display_name")
+    )

--- a/alex/connectors/semantic_scholar.py
+++ b/alex/connectors/semantic_scholar.py
@@ -12,6 +12,18 @@ def search(client: HttpClient, query: str, limit: int = 25) -> list[dict[str, An
     })
     return (data or {}).get("data", [])
 
+PAPER = "https://api.semanticscholar.org/graph/v1/paper"
+
+
+def get_paper(client: HttpClient, paper_id: str) -> dict[str, Any] | None:
+    """Fetch a single paper by Semantic Scholar paper ID."""
+    data = client.get_json(
+        f"{PAPER}/{paper_id}",
+        params={"fields": "title,abstract,authors,venue,year,citationCount,externalIds,url"},
+    )
+    return data
+
+
 def references(item: dict[str, Any]) -> list[dict[str, Any]]:
     return item.get("references") or []
 

--- a/alex/pipelines/citation_chain.py
+++ b/alex/pipelines/citation_chain.py
@@ -29,12 +29,12 @@ def run() -> None:
                     seen.add(key)
                     rows.append({
                         "title": ct,
-                        "authors": "",
+                        "authors": openalex.author_names(cited),
                         "year": cited.get("publication_year", ""),
-                        "venue": ((cited.get("primary_location") or {}).get("source") or {}).get("display_name", ""),
-                        "doi": ((cited.get("ids") or {}).get("doi", "") or "").replace("https://doi.org/", ""),
+                        "venue": openalex.venue_name(cited),
+                        "doi": openalex.doi(cited),
                         "abstract": "",
-                        "source_url": (cited.get("primary_location") or {}).get("landing_page_url", ""),
+                        "source_url": openalex.landing_url(cited),
                         "discovery_source": "OpenAlex citation chain",
                         "discovery_query": title,
                         "inclusion_path": "forward chaining",

--- a/alex/pipelines/citation_chain.py
+++ b/alex/pipelines/citation_chain.py
@@ -16,7 +16,11 @@ def run() -> None:
     rows = []
     seen = set(normalize_title(str(t)) for t in df["title"].tolist())
 
-    for _, row in df.head(100).iterrows():
+    # Sort by citation count descending so highest-quality candidates get chained first
+    sorted_df = df.copy()
+    sorted_df["citation_count"] = pd.to_numeric(sorted_df["citation_count"], errors="coerce").fillna(0)
+    sorted_df = sorted_df.sort_values("citation_count", ascending=False).head(100)
+    for _, row in sorted_df.iterrows():
         title = clean(row.get("title"))
         # openalex title search
         results = openalex.search(client, title, os.getenv("HARVEST_MAILTO", ""), per_page=3)

--- a/alex/pipelines/citation_chain.py
+++ b/alex/pipelines/citation_chain.py
@@ -41,30 +41,35 @@ def run() -> None:
                         "citation_count": cited.get("cited_by_count", 0),
                         "reference_count": len(cited.get("referenced_works") or []),
                     })
-        # semantic scholar
+        # Semantic Scholar backward chaining
         ss_results = semantic_scholar.search(client, title, limit=3)
         for item in ss_results:
             for ref in semantic_scholar.references(item)[:5]:
                 pid = ref.get("paperId")
-                if pid:
-                    rt = f"Referenced paper {pid}"
-                    key = normalize_title(rt)
-                    if key not in seen:
-                        seen.add(key)
-                        rows.append({
-                            "title": rt,
-                            "authors": "",
-                            "year": "",
-                            "venue": "",
-                            "doi": "",
-                            "abstract": "",
-                            "source_url": "",
-                            "discovery_source": "Semantic Scholar citation chain",
-                            "discovery_query": title,
-                            "inclusion_path": "backward chaining",
-                            "citation_count": "",
-                            "reference_count": "",
-                        })
+                if not pid:
+                    continue
+                paper = semantic_scholar.get_paper(client, pid)
+                if not paper or not paper.get("title"):
+                    continue
+                rt = clean(paper["title"])
+                key = normalize_title(rt)
+                if key and key not in seen:
+                    seen.add(key)
+                    ext = paper.get("externalIds") or {}
+                    rows.append({
+                        "title": rt,
+                        "authors": "; ".join(a.get("name", "") for a in (paper.get("authors") or []) if a.get("name")),
+                        "year": paper.get("year", ""),
+                        "venue": paper.get("venue", ""),
+                        "doi": ext.get("DOI", ""),
+                        "abstract": clean(paper.get("abstract", "")),
+                        "source_url": paper.get("url", ""),
+                        "discovery_source": "Semantic Scholar citation chain",
+                        "discovery_query": title,
+                        "inclusion_path": "backward chaining",
+                        "citation_count": paper.get("citationCount", 0),
+                        "reference_count": "",
+                    })
 
     if rows:
         add_df = pd.DataFrame(rows)

--- a/alex/pipelines/citation_chain.py
+++ b/alex/pipelines/citation_chain.py
@@ -14,7 +14,7 @@ def run() -> None:
         return
 
     rows = []
-    seen = set(normalize_title(t) for t in df.get("title", []).tolist())
+    seen = set(normalize_title(str(t)) for t in df["title"].tolist())
 
     for _, row in df.head(100).iterrows():
         title = clean(row.get("title"))

--- a/alex/pipelines/classify.py
+++ b/alex/pipelines/classify.py
@@ -1,48 +1,77 @@
 from __future__ import annotations
-import os, json
+import json
+import logging
+import os
+
 import pandas as pd
 import requests
+
 from alex.utils.io import load_df, save_df, root_file
 from alex.utils.text import clean, unique_keep
 
+logger = logging.getLogger(__name__)
+
+# Note: uses requests.post directly (not HttpClient) because LLM calls should NOT be cached
+# and the OpenAI API requires POST, not GET.
 OPENAI_URL = "https://api.openai.com/v1/responses"
 
-PROMPT = '''
+PROMPT = """
 Classify this OSINT / cyber investigation paper into:
-- Category
-- Investigation_Type
-- OSINT_Source_Types
-- Keywords
-- Tags
+- Category (e.g., Digital Forensics, Threat Intelligence, OSINT Methodology, Network Security, Privacy & Surveillance, Cybercrime, Other)
+- Investigation_Type (e.g., Network Investigation, Social Media Analysis, Dark Web Analysis, Malware Analysis, Attribution, Other)
+- OSINT_Source_Types (list, e.g., Social Media, Public Records, Dark Web, DNS/WHOIS, Satellite Imagery, Government Data)
+- Keywords (list of key terms)
+- Tags (list of miscellaneous labels)
+- Quality_Tier (one of: Seminal, High, Standard, Exploratory)
 Return JSON only.
-'''
+"""
+
+FALLBACK = {
+    "Category": "Other",
+    "Investigation_Type": "Other",
+    "OSINT_Source_Types": [],
+    "Keywords": [],
+    "Tags": [],
+    "Quality_Tier": "Standard",
+}
+
+
+def _safe_citation_count(row: dict) -> float:
+    try:
+        return float(row.get("citation_count") or 0)
+    except (ValueError, TypeError):
+        return 0.0
+
 
 def call_openai(row: dict) -> dict:
     api_key = os.getenv("OPENAI_API_KEY", "")
     model = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
     if not api_key:
-        return {
-            "Category": "Other",
-            "Investigation_Type": "Other",
-            "OSINT_Source_Types": [],
-            "Keywords": [],
-            "Tags": []
-        }
+        return dict(FALLBACK)
     headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
     body = {
         "model": model,
         "input": [
             {"role": "system", "content": [{"type": "input_text", "text": PROMPT}]},
             {"role": "user", "content": [{"type": "input_text", "text": json.dumps(row, ensure_ascii=False)}]},
-        ]
+        ],
     }
-    r = requests.post(OPENAI_URL, headers=headers, json=body, timeout=60)
-    r.raise_for_status()
-    data = r.json()
-    text = data.get("output_text", "")
-    return json.loads(text) if text else {
-        "Category": "Other", "Investigation_Type": "Other", "OSINT_Source_Types": [], "Keywords": [], "Tags": []
-    }
+    try:
+        r = requests.post(OPENAI_URL, headers=headers, json=body, timeout=60)
+        r.raise_for_status()
+        data = r.json()
+        text = data.get("output_text", "")
+        if text:
+            return json.loads(text)
+        logger.warning("Empty output_text from OpenAI for: %s", row.get("title", ""))
+        return dict(FALLBACK)
+    except requests.exceptions.RequestException as exc:
+        logger.warning("OpenAI request failed for '%s': %s", row.get("title", ""), exc)
+        return dict(FALLBACK)
+    except json.JSONDecodeError as exc:
+        logger.warning("OpenAI returned invalid JSON for '%s': %s", row.get("title", ""), exc)
+        return dict(FALLBACK)
+
 
 def run() -> None:
     df = load_df(root_file("data", "accepted_harvested.csv"))
@@ -64,7 +93,8 @@ def run() -> None:
         out["OSINT_Source_Types"] = "; ".join(unique_keep(tags.get("OSINT_Source_Types", [])))
         out["Keywords"] = "; ".join(unique_keep(tags.get("Keywords", [])))
         out["Tags"] = "; ".join(unique_keep(tags.get("Tags", [])))
-        out["Seminal_Flag"] = "TRUE" if float(row.get("citation_count") or 0) >= 500 else "FALSE"
+        out["Quality_Tier"] = tags.get("Quality_Tier", "Standard")
+        out["Seminal_Flag"] = "TRUE" if _safe_citation_count(row) >= 500 else "FALSE"
         rows.append(out)
     save_df(root_file("data", "accepted_classified.csv"), pd.DataFrame(rows))
     print(f"Classified {len(rows)} papers")

--- a/alex/pipelines/classify.py
+++ b/alex/pipelines/classify.py
@@ -36,7 +36,7 @@ FALLBACK = {
 }
 
 
-def _safe_citation_count(row: dict) -> float:
+def _safe_citation_count(row) -> float:
     try:
         return float(row.get("citation_count") or 0)
     except (ValueError, TypeError):

--- a/alex/pipelines/classify.py
+++ b/alex/pipelines/classify.py
@@ -6,7 +6,7 @@ import os
 import pandas as pd
 import requests
 
-from alex.utils.io import load_df, save_df, root_file
+from alex.utils.io import load_df, save_df, root_file, validate_columns
 from alex.utils.text import clean, unique_keep
 
 logger = logging.getLogger(__name__)
@@ -78,6 +78,7 @@ def run() -> None:
     if df.empty:
         print("No harvested accepted candidates to classify.")
         return
+    validate_columns(df, ["title", "abstract", "venue", "authors", "citation_count"], "accepted_harvested.csv")
     rows = []
     for _, row in df.iterrows():
         payload = {

--- a/alex/pipelines/discovery.py
+++ b/alex/pipelines/discovery.py
@@ -93,7 +93,7 @@ def run() -> None:
                 discovery_query=query,
             )
 
-        for item in arxiv.search(query):
+        for item in arxiv.search(client, query):
             add_row(
                 item.get("title", ""),
                 "arXiv",

--- a/alex/pipelines/discovery.py
+++ b/alex/pipelines/discovery.py
@@ -35,16 +35,14 @@ def run() -> None:
 
     for query in queries:
         for item in openalex.search(client, query, os.getenv("HARVEST_MAILTO", "")):
-            ids = item.get("ids") or {}
-            authors = "; ".join((a.get("author") or {}).get("display_name", "") for a in (item.get("authorships") or []) if (a.get("author") or {}).get("display_name"))
             add_row(
                 item.get("title", ""),
                 "OpenAlex",
-                authors=authors,
+                authors=openalex.author_names(item),
                 year=item.get("publication_year", ""),
-                venue=((item.get("primary_location") or {}).get("source") or {}).get("display_name", ""),
-                doi=(ids.get("doi", "") or "").replace("https://doi.org/", ""),
-                source_url=(item.get("primary_location") or {}).get("landing_page_url", ""),
+                venue=openalex.venue_name(item),
+                doi=openalex.doi(item),
+                source_url=openalex.landing_url(item),
                 citation_count=item.get("cited_by_count", 0),
                 reference_count=len(item.get("referenced_works") or []),
                 discovery_query=query,

--- a/alex/pipelines/discovery.py
+++ b/alex/pipelines/discovery.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import os
 import pandas as pd
-from alex.utils.io import load_json, save_df, root_file
+from alex.utils.io import load_json, load_df, save_df, root_file
 from alex.utils.http import HttpClient
 from alex.utils.text import clean, normalize_title
 from alex.connectors import openalex, crossref, semantic_scholar, core, arxiv, zenodo, github_search
@@ -11,6 +11,15 @@ def run() -> None:
     client = HttpClient(mailto=os.getenv("HARVEST_MAILTO", ""))
     rows = []
     seen = set()
+
+    # Load existing candidates to avoid re-adding known papers
+    existing_path = root_file("data", "discovery_candidates.csv")
+    existing_df = load_df(existing_path)
+    if not existing_df.empty:
+        for t in existing_df["title"].tolist():
+            key = normalize_title(str(t))
+            if key:
+                seen.add(key)
 
     def add_row(title: str, source: str, **kwargs):
         key = normalize_title(title)
@@ -129,6 +138,12 @@ def run() -> None:
                 citation_count=0,
             )
 
-    df = pd.DataFrame(rows)
-    save_df(root_file("data", "discovery_candidates.csv"), df)
-    print(f"Discovered {len(df)} candidates")
+    new_df = pd.DataFrame(rows)
+    if not existing_df.empty and not new_df.empty:
+        df = pd.concat([existing_df, new_df], ignore_index=True)
+    elif not new_df.empty:
+        df = new_df
+    else:
+        df = existing_df
+    save_df(existing_path, df)
+    print(f"Discovered {len(rows)} new candidates ({len(df)} total)")

--- a/alex/pipelines/harvest.py
+++ b/alex/pipelines/harvest.py
@@ -4,7 +4,7 @@ import pandas as pd
 from alex.utils.io import load_df, save_df, root_file
 from alex.utils.http import HttpClient
 from alex.connectors import crossref, openalex, semantic_scholar
-from alex.utils.text import clean, strip_html_tags
+from alex.utils.text import clean
 
 def run() -> None:
     df = load_df(root_file("data", "accepted_candidates.csv"))

--- a/alex/pipelines/harvest.py
+++ b/alex/pipelines/harvest.py
@@ -38,9 +38,9 @@ def run() -> None:
             oa = openalex.search(client, title, os.getenv("HARVEST_MAILTO", ""), per_page=1)
             if oa:
                 work = oa[0]
-                best["doi"] = clean(((work.get("ids") or {}).get("doi", "") or "")).replace("https://doi.org/", "") or best.get("doi", "")
-                best["venue"] = ((work.get("primary_location") or {}).get("source") or {}).get("display_name", "") or best.get("venue", "")
-                best["source_url"] = (work.get("primary_location") or {}).get("landing_page_url", "") or best.get("source_url", "")
+                best["doi"] = clean(openalex.doi(work)) or best.get("doi", "")
+                best["venue"] = openalex.venue_name(work) or best.get("venue", "")
+                best["source_url"] = openalex.landing_url(work) or best.get("source_url", "")
                 best["citation_count"] = work.get("cited_by_count", best.get("citation_count", 0))
                 best["reference_count"] = len(work.get("referenced_works") or [])
                 best["harvest_source"] = best.get("harvest_source", "OpenAlex search")

--- a/alex/pipelines/harvest.py
+++ b/alex/pipelines/harvest.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import os
 import pandas as pd
-from alex.utils.io import load_df, save_df, root_file
+from alex.utils.io import load_df, save_df, root_file, validate_columns
 from alex.utils.http import HttpClient
 from alex.connectors import crossref, openalex, semantic_scholar
 from alex.utils.text import clean
@@ -11,6 +11,7 @@ def run() -> None:
     if df.empty:
         print("No accepted candidates to harvest.")
         return
+    validate_columns(df, ["title", "doi", "authors", "venue", "abstract"], "accepted_candidates.csv")
 
     client = HttpClient(mailto=os.getenv("HARVEST_MAILTO", ""))
     harvested = []

--- a/alex/pipelines/publish.py
+++ b/alex/pipelines/publish.py
@@ -31,7 +31,7 @@ def run() -> None:
             "link": link,
             "source_url": src,
             "doi": doi,
-            "seminal": row.get("Seminal_Flag", "FALSE") == "TRUE",
+            "seminal": str(row.get("Seminal_Flag", "FALSE")).upper() == "TRUE",
             "quality_tier": row.get("Quality_Tier", "Standard"),
         })
     save_json(root_file("data", "papers.json"), papers)

--- a/alex/pipelines/publish.py
+++ b/alex/pipelines/publish.py
@@ -1,6 +1,4 @@
 from __future__ import annotations
-import json
-import pandas as pd
 from alex.utils.io import load_df, save_df, save_json, root_file
 from alex.utils.text import split_multi
 
@@ -14,12 +12,12 @@ def run() -> None:
     save_df(root_file("data", "osint_cyber_papers.csv"), public)
 
     papers = []
-    for _, row in public.iterrows():
+    for i, (_, row) in enumerate(public.iterrows()):
         doi = str(row.get("doi", "")).strip()
         src = str(row.get("source_url", "")).strip()
         link = f"https://doi.org/{doi}" if doi else src
         papers.append({
-            "id": int(row.name) + 1,
+            "id": i + 1,
             "title": row.get("title", ""),
             "author": row.get("authors", ""),
             "year": row.get("year", ""),
@@ -32,7 +30,9 @@ def run() -> None:
             "tags": split_multi(row.get("Tags", "")),
             "link": link,
             "source_url": src,
-            "doi": doi
+            "doi": doi,
+            "seminal": row.get("Seminal_Flag", "FALSE") == "TRUE",
+            "quality_tier": row.get("Quality_Tier", "Standard"),
         })
     save_json(root_file("data", "papers.json"), papers)
     print(f"Published {len(papers)} papers")

--- a/alex/pipelines/quality_gate.py
+++ b/alex/pipelines/quality_gate.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 
 import pandas as pd
 
-from alex.utils.io import load_df, save_df, load_json, root_file
+from alex.utils.io import load_df, save_df, load_json, root_file, validate_columns
 from alex.utils.scoring import venue_score, citation_score, institution_score, usage_score, relevance_score
 from alex.utils.text import clean
 
@@ -30,6 +30,7 @@ def run() -> None:
     if df.empty:
         print("No discovery candidates to score.")
         return
+    validate_columns(df, ["title", "authors", "year", "venue", "doi", "citation_count"], "discovery_candidates.csv")
 
     whitelist = load_json(root_file("config", "venue_whitelist.json"))["high_trust"]
     queries = load_json(root_file("config", "query_registry.json"))["queries"]

--- a/alex/pipelines/quality_gate.py
+++ b/alex/pipelines/quality_gate.py
@@ -1,8 +1,29 @@
 from __future__ import annotations
+import logging
+from datetime import datetime, timezone
+
 import pandas as pd
+
 from alex.utils.io import load_df, save_df, load_json, root_file
 from alex.utils.scoring import venue_score, citation_score, institution_score, usage_score, relevance_score
 from alex.utils.text import clean
+
+logger = logging.getLogger(__name__)
+
+
+def _safe_float(val, default: float = 0.0) -> float:
+    try:
+        return float(val) if val is not None and val != "" else default
+    except (ValueError, TypeError):
+        return default
+
+
+def _safe_int_year(val) -> int | None:
+    s = clean(val)
+    if s.isdigit():
+        return int(s)
+    return None
+
 
 def run() -> None:
     df = load_df(root_file("data", "discovery_candidates.csv"))
@@ -13,27 +34,30 @@ def run() -> None:
     whitelist = load_json(root_file("config", "venue_whitelist.json"))["high_trust"]
     queries = load_json(root_file("config", "query_registry.json"))["queries"]
     weights = load_json(root_file("config", "quality_weights.json"))
+    now = datetime.now(timezone.utc).isoformat()
 
     metrics = []
     accepted, review, rejected = [], [], []
 
-    for idx, row in df.iterrows():
+    for i, (idx, row) in enumerate(df.iterrows()):
         v = venue_score(row.get("venue", ""), whitelist)
-        c = citation_score(float(row.get("citation_count") or 0), int(row.get("year")) if clean(row.get("year")).isdigit() else None)
-        i = institution_score(row.get("authors", ""))
+        c = citation_score(_safe_float(row.get("citation_count")), _safe_int_year(row.get("year")))
+        i_score = institution_score(row.get("authors", ""))
         u = usage_score()
         r = relevance_score(row.get("title", ""), row.get("abstract", ""), queries)
         total = 100 * (
-            v * weights["venue"] +
-            c * weights["citations"] +
-            i * weights["institution"] +
-            u * weights["usage"] +
-            r * weights["relevance"]
+            v * weights["venue"]
+            + c * weights["citations"]
+            + i_score * weights["institution"]
+            + u * weights["usage"]
+            + r * weights["relevance"]
         )
         out = dict(row)
+        out["candidate_id"] = i + 1
+        out["scored_at"] = now
         out["venue_score"] = round(v * 100, 2)
         out["citation_score"] = round(c * 100, 2)
-        out["institution_score"] = round(i * 100, 2)
+        out["institution_score"] = round(i_score * 100, 2)
         out["usage_score"] = round(u * 100, 2)
         out["relevance_score"] = round(r * 100, 2)
         out["total_quality_score"] = round(total, 2)
@@ -56,4 +80,5 @@ def run() -> None:
     save_df(root_file("data", "review_queue.csv"), pd.DataFrame(review))
     save_df(root_file("data", "rejected_candidates.csv"), pd.DataFrame(rejected))
     save_df(root_file("data", "accepted_candidates.csv"), pd.DataFrame(accepted))
+    logger.info("Quality gate: Accepted=%d Review=%d Rejected=%d", len(accepted), len(review), len(rejected))
     print(f"Accepted={len(accepted)} Review={len(review)} Rejected={len(rejected)}")

--- a/alex/pipelines/quality_gate.py
+++ b/alex/pipelines/quality_gate.py
@@ -39,7 +39,7 @@ def run() -> None:
     metrics = []
     accepted, review, rejected = [], [], []
 
-    for i, (idx, row) in enumerate(df.iterrows()):
+    for i, (_, row) in enumerate(df.iterrows()):
         v = venue_score(row.get("venue", ""), whitelist)
         c = citation_score(_safe_float(row.get("citation_count")), _safe_int_year(row.get("year")))
         i_score = institution_score(row.get("authors", ""))

--- a/alex/utils/http.py
+++ b/alex/utils/http.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 import json
-import os
+import logging
 import time
 from pathlib import Path
 from typing import Any, Optional
 import requests
 
-CACHE = Path(".alex_cache.json")
+logger = logging.getLogger(__name__)
+
+CACHE = Path(__file__).resolve().parents[2] / ".alex_cache.json"
+
 
 class HttpClient:
     def __init__(self, mailto: str = "") -> None:
@@ -17,30 +20,41 @@ class HttpClient:
         self.session.headers.update({"User-Agent": ua, "Accept": "application/json"})
         if CACHE.exists():
             try:
-                self.cache = json.loads(CACHE.read_text(encoding="utf-8"))
+                self.cache: dict[str, Any] = json.loads(CACHE.read_text(encoding="utf-8"))
             except Exception:
                 self.cache = {}
         else:
             self.cache = {}
+        # Purge legacy None entries from cache
+        stale = [k for k, v in self.cache.items() if v is None]
+        if stale:
+            for k in stale:
+                del self.cache[k]
+            self._save_cache()
+            logger.info("Purged %d stale None entries from cache", len(stale))
 
     def _save_cache(self) -> None:
         CACHE.write_text(json.dumps(self.cache, ensure_ascii=False, indent=2), encoding="utf-8")
 
-    def get_json(self, url: str, params: Optional[dict[str, Any]] = None, headers: Optional[dict[str, str]] = None, timeout: int = 30):
+    def get_json(
+        self,
+        url: str,
+        params: Optional[dict[str, Any]] = None,
+        headers: Optional[dict[str, str]] = None,
+        timeout: int = 30,
+    ) -> Any:
         key = json.dumps({"url": url, "params": params or {}, "headers": headers or {}}, sort_keys=True)
         if key in self.cache:
             return self.cache[key]
         try:
             r = self.session.get(url, params=params, headers=headers, timeout=timeout)
-            if r.status_code == 200:
-                data = r.json()
-                self.cache[key] = data
-                self._save_cache()
-                time.sleep(0.5)
-                return data
-        except Exception:
-            pass
-        self.cache[key] = None
-        self._save_cache()
-        time.sleep(0.5)
-        return None
+            r.raise_for_status()
+            data = r.json()
+            self.cache[key] = data
+            self._save_cache()
+            return data
+        except (requests.exceptions.RequestException, ValueError) as exc:
+            logger.warning("HTTP request failed for %s: %s", url, exc)
+            return None
+        finally:
+            time.sleep(0.5)

--- a/alex/utils/io.py
+++ b/alex/utils/io.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 import json
+import logging
 from pathlib import Path
 import pandas as pd
+
+logger = logging.getLogger(__name__)
 
 ROOT = Path(__file__).resolve().parents[2]
 DATA_DIR = ROOT / "data"
@@ -28,3 +31,10 @@ def save_df(path: Path, df: pd.DataFrame) -> None:
 
 def root_file(*parts: str) -> Path:
     return ROOT.joinpath(*parts)
+
+
+def validate_columns(df: pd.DataFrame, required: list[str], context: str = "") -> None:
+    """Log a warning if the DataFrame is missing expected columns."""
+    missing = [c for c in required if c not in df.columns]
+    if missing:
+        logger.warning("Missing columns in %s: %s", context or "DataFrame", missing)

--- a/alex/utils/io.py
+++ b/alex/utils/io.py
@@ -22,7 +22,10 @@ def save_json(path: Path, obj) -> None:
 
 def load_df(path: Path) -> pd.DataFrame:
     if path.exists():
-        return pd.read_csv(path)
+        try:
+            return pd.read_csv(path)
+        except pd.errors.EmptyDataError:
+            return pd.DataFrame()
     return pd.DataFrame()
 
 def save_df(path: Path, df: pd.DataFrame) -> None:

--- a/alex/utils/scoring.py
+++ b/alex/utils/scoring.py
@@ -1,36 +1,41 @@
 from __future__ import annotations
 from math import log1p
+from typing import Any
 from .text import clean
 
-def venue_score(venue: str, whitelist: list[str]) -> float:
+
+def venue_score(venue: Any, whitelist: list[str]) -> float:
     v = clean(venue)
     if not v:
         return 0.2
     return 1.0 if any(x.lower() in v.lower() for x in whitelist) else 0.4
 
-def citation_score(citations: float, year: int | None, current_year: int = 2026) -> float:
-    if citations is None:
+
+def citation_score(citations: float | None, year: int | None, current_year: int = 2026) -> float:
+    if citations is None or citations == 0:
         return 0.0
     age = max(1, current_year - year + 1) if year else 1
     normalized = citations / age
     return min(1.0, log1p(normalized) / log1p(100))
 
-def institution_score(affiliations: str) -> float:
-    # heuristic placeholder, can be upgraded with ROR integration
+
+def institution_score(affiliations: Any) -> float:
     text = clean(affiliations).lower()
     trusted = ["university", "institute", "laboratory", "nato", "rand", "oxford", "cambridge", "mit", "stanford"]
     if any(x in text for x in trusted):
         return 0.8
     return 0.4 if text else 0.2
 
+
 def usage_score(downloads: float | None = None, stars: float | None = None, altmetric: float | None = None) -> float:
-    parts = []
+    parts: list[float] = []
     for value, scale in ((downloads, 1000), (stars, 500), (altmetric, 100)):
         if value is not None:
             parts.append(min(1.0, value / scale))
     return sum(parts) / len(parts) if parts else 0.0
 
-def relevance_score(title: str, abstract: str, queries: list[str]) -> float:
-    haystack = f"{title} {abstract}".lower()
+
+def relevance_score(title: Any, abstract: Any, queries: list[str]) -> float:
+    haystack = f"{clean(title)} {clean(abstract)}".lower()
     hits = sum(1 for q in queries if q.lower() in haystack)
     return min(1.0, hits / max(1, len(queries) / 4))

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_functions = test_*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pandas>=2.2.0
 openpyxl>=3.1.0
 requests>=2.31.0
+pytest>=8.0.0

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -1,0 +1,84 @@
+from alex.connectors import openalex, crossref, semantic_scholar
+
+
+class TestOpenAlexAccessors:
+    def test_venue_name(self):
+        work = {"primary_location": {"source": {"display_name": "IEEE S&P"}}}
+        assert openalex.venue_name(work) == "IEEE S&P"
+
+    def test_venue_name_missing(self):
+        assert openalex.venue_name({}) == ""
+        assert openalex.venue_name({"primary_location": None}) == ""
+        assert openalex.venue_name({"primary_location": {"source": None}}) == ""
+
+    def test_doi(self):
+        work = {"ids": {"doi": "https://doi.org/10.1234/test"}}
+        assert openalex.doi(work) == "10.1234/test"
+
+    def test_doi_missing(self):
+        assert openalex.doi({}) == ""
+        assert openalex.doi({"ids": None}) == ""
+
+    def test_landing_url(self):
+        work = {"primary_location": {"landing_page_url": "https://example.com"}}
+        assert openalex.landing_url(work) == "https://example.com"
+
+    def test_landing_url_missing(self):
+        assert openalex.landing_url({}) == ""
+
+    def test_author_names(self):
+        work = {"authorships": [
+            {"author": {"display_name": "Alice"}},
+            {"author": {"display_name": "Bob"}},
+        ]}
+        assert openalex.author_names(work) == "Alice; Bob"
+
+    def test_author_names_missing(self):
+        assert openalex.author_names({}) == ""
+
+    def test_cited_by_api_url(self):
+        work = {"cited_by_api_url": "https://api.openalex.org/works?filter=cites:W123"}
+        assert openalex.cited_by_api_url(work) == "https://api.openalex.org/works?filter=cites:W123"
+
+    def test_references(self):
+        work = {"referenced_works": ["W1", "W2"]}
+        assert openalex.references(work) == ["W1", "W2"]
+
+    def test_references_missing(self):
+        assert openalex.references({}) == []
+
+
+class TestCrossrefParsing:
+    def test_abstract_strips_html(self):
+        item = {"abstract": "<jats:p>Hello <b>world</b></jats:p>"}
+        result = crossref.abstract(item)
+        assert "Hello" in result
+        assert "<" not in result
+
+    def test_venue_from_container(self):
+        item = {"container-title": ["IEEE S&P"]}
+        assert crossref.venue(item) == "IEEE S&P"
+
+    def test_venue_from_publisher(self):
+        item = {"container-title": [], "publisher": "Springer"}
+        assert crossref.venue(item) == "Springer"
+
+    def test_venue_missing(self):
+        item = {"container-title": []}
+        assert crossref.venue(item) == ""
+
+
+class TestSemanticScholarParsing:
+    def test_references(self):
+        item = {"references": [{"paperId": "abc"}, {"paperId": "def"}]}
+        assert semantic_scholar.references(item) == [{"paperId": "abc"}, {"paperId": "def"}]
+
+    def test_references_missing(self):
+        assert semantic_scholar.references({}) == []
+
+    def test_citations(self):
+        item = {"citations": [{"paperId": "xyz"}]}
+        assert semantic_scholar.citations(item) == [{"paperId": "xyz"}]
+
+    def test_citations_missing(self):
+        assert semantic_scholar.citations({}) == []

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,0 +1,98 @@
+import json
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+from alex.utils.http import HttpClient
+
+
+class TestHttpClientCache:
+    def test_successful_response_is_cached(self, tmp_path):
+        cache_path = tmp_path / ".alex_cache.json"
+        with patch("alex.utils.http.CACHE", cache_path), \
+             patch("alex.utils.http.time.sleep"):
+            client = HttpClient()
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {"results": [1, 2]}
+            with patch.object(client.session, "get", return_value=mock_resp):
+                result = client.get_json("https://example.com/api", params={"q": "test"})
+            assert result == {"results": [1, 2]}
+            # Second call should use cache
+            with patch.object(client.session, "get") as mock_get:
+                result2 = client.get_json("https://example.com/api", params={"q": "test"})
+                mock_get.assert_not_called()
+            assert result2 == {"results": [1, 2]}
+
+    def test_failed_response_is_not_cached(self, tmp_path):
+        cache_path = tmp_path / ".alex_cache.json"
+        with patch("alex.utils.http.CACHE", cache_path), \
+             patch("alex.utils.http.time.sleep"):
+            client = HttpClient()
+            mock_resp = MagicMock()
+            mock_resp.status_code = 500
+            import requests as req
+            mock_resp.raise_for_status.side_effect = req.exceptions.HTTPError("Server error")
+            with patch.object(client.session, "get", return_value=mock_resp):
+                result = client.get_json("https://example.com/api")
+            assert result is None
+            # Cache should NOT contain the None entry
+            assert len(client.cache) == 0
+
+    def test_network_error_is_not_cached(self, tmp_path):
+        cache_path = tmp_path / ".alex_cache.json"
+        with patch("alex.utils.http.CACHE", cache_path), \
+             patch("alex.utils.http.time.sleep"):
+            client = HttpClient()
+            import requests as req
+            with patch.object(client.session, "get", side_effect=req.exceptions.ConnectionError("timeout")):
+                result = client.get_json("https://example.com/api")
+            assert result is None
+            assert len(client.cache) == 0
+
+    def test_cache_persists_to_disk(self, tmp_path):
+        cache_path = tmp_path / ".alex_cache.json"
+        with patch("alex.utils.http.CACHE", cache_path), \
+             patch("alex.utils.http.time.sleep"):
+            client = HttpClient()
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {"data": "value"}
+            with patch.object(client.session, "get", return_value=mock_resp):
+                client.get_json("https://example.com/api")
+            assert cache_path.exists()
+            saved = json.loads(cache_path.read_text())
+            assert len(saved) == 1
+
+    def test_loads_existing_cache(self, tmp_path):
+        cache_path = tmp_path / ".alex_cache.json"
+        key = json.dumps({"url": "https://example.com/api", "params": {}, "headers": {}}, sort_keys=True)
+        cache_path.write_text(json.dumps({key: {"cached": True}}))
+        with patch("alex.utils.http.CACHE", cache_path), \
+             patch("alex.utils.http.time.sleep"):
+            client = HttpClient()
+            result = client.get_json("https://example.com/api")
+        assert result == {"cached": True}
+
+    def test_purges_legacy_none_entries(self, tmp_path):
+        cache_path = tmp_path / ".alex_cache.json"
+        key = json.dumps({"url": "https://example.com/stale", "params": {}, "headers": {}}, sort_keys=True)
+        cache_path.write_text(json.dumps({key: None}))
+        with patch("alex.utils.http.CACHE", cache_path), \
+             patch("alex.utils.http.time.sleep"):
+            client = HttpClient()
+        assert len(client.cache) == 0
+        saved = json.loads(cache_path.read_text())
+        assert len(saved) == 0
+
+    def test_malformed_json_response_not_cached(self, tmp_path):
+        cache_path = tmp_path / ".alex_cache.json"
+        with patch("alex.utils.http.CACHE", cache_path), \
+             patch("alex.utils.http.time.sleep"):
+            client = HttpClient()
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.raise_for_status.return_value = None
+            mock_resp.json.side_effect = ValueError("Invalid JSON")
+            with patch.object(client.session, "get", return_value=mock_resp):
+                result = client.get_json("https://example.com/api")
+            assert result is None
+            assert len(client.cache) == 0

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 from unittest.mock import patch, MagicMock
 from alex.utils.http import HttpClient
 

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -1,0 +1,82 @@
+import json
+from unittest.mock import patch
+import pandas as pd
+from alex.pipelines import quality_gate, publish
+
+
+class TestQualityGate:
+    def test_routing_logic(self, tmp_path):
+        """Papers are routed to accept/review/reject based on score thresholds."""
+        candidates = pd.DataFrame([
+            {"title": "High Quality Paper on OSINT", "authors": "MIT University", "year": "2024",
+             "venue": "IEEE Security & Privacy", "doi": "10.1234/a", "abstract": "OSINT methodology cybersecurity",
+             "source_url": "", "discovery_source": "test", "discovery_query": "OSINT",
+             "inclusion_path": "discovery", "citation_count": 100, "reference_count": 5},
+            {"title": "Mediocre Paper", "authors": "John Rogers", "year": "2020",
+             "venue": "Unknown Journal", "doi": "", "abstract": "",
+             "source_url": "", "discovery_source": "test", "discovery_query": "test",
+             "inclusion_path": "discovery", "citation_count": 0, "reference_count": 0},
+        ])
+        candidates_path = tmp_path / "data" / "discovery_candidates.csv"
+        candidates_path.parent.mkdir(parents=True)
+        candidates.to_csv(candidates_path, index=False)
+
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        (config_dir / "venue_whitelist.json").write_text(json.dumps({"high_trust": ["IEEE"]}))
+        (config_dir / "query_registry.json").write_text(json.dumps({"queries": ["OSINT", "cybersecurity"]}))
+        (config_dir / "quality_weights.json").write_text(json.dumps({
+            "venue": 0.25, "citations": 0.3, "institution": 0.15,
+            "usage": 0.1, "relevance": 0.2,
+            "auto_include_threshold": 75.0, "review_threshold": 45.0,
+        }))
+
+        with patch("alex.utils.io.ROOT", tmp_path), \
+             patch("alex.utils.io.DATA_DIR", tmp_path / "data"), \
+             patch("alex.utils.io.CONFIG_DIR", tmp_path / "config"):
+            quality_gate.run()
+
+        from alex.utils.io import load_df
+        accepted = load_df(tmp_path / "data" / "accepted_candidates.csv")
+        review = load_df(tmp_path / "data" / "review_queue.csv")
+        rejected = load_df(tmp_path / "data" / "rejected_candidates.csv")
+        metrics = load_df(tmp_path / "data" / "quality_metrics.csv")
+
+        assert len(metrics) == 2
+        assert "candidate_id" in metrics.columns
+        assert "scored_at" in metrics.columns
+        assert len(accepted) + len(review) + len(rejected) == 2
+        # The IEEE paper with high citations from MIT should score highest
+        high_score = metrics.loc[metrics["title"].str.contains("High Quality"), "total_quality_score"].iloc[0]
+        low_score = metrics.loc[metrics["title"].str.contains("Mediocre"), "total_quality_score"].iloc[0]
+        assert high_score > low_score
+
+
+class TestPublish:
+    def test_json_output_structure(self, tmp_path):
+        classified = pd.DataFrame([{
+            "title": "Test Paper", "authors": "Author A", "year": "2024",
+            "venue": "IEEE", "doi": "10.1234/test", "abstract": "An abstract",
+            "source_url": "https://example.com", "Category": "OSINT Methodology",
+            "Investigation_Type": "Network Investigation",
+            "OSINT_Source_Types": "Social Media; DNS/WHOIS",
+            "Keywords": "OSINT; network", "Tags": "review",
+            "Seminal_Flag": "TRUE", "Quality_Tier": "High",
+        }])
+        classified_path = tmp_path / "data" / "accepted_classified.csv"
+        classified_path.parent.mkdir(parents=True)
+        classified.to_csv(classified_path, index=False)
+
+        with patch("alex.utils.io.ROOT", tmp_path), \
+             patch("alex.utils.io.DATA_DIR", tmp_path / "data"), \
+             patch("alex.utils.io.CONFIG_DIR", tmp_path / "config"):
+            publish.run()
+
+        papers_json = json.loads((tmp_path / "data" / "papers.json").read_text())
+        assert len(papers_json) == 1
+        paper = papers_json[0]
+        assert paper["title"] == "Test Paper"
+        assert paper["link"] == "https://doi.org/10.1234/test"
+        assert paper["seminal"] is True
+        assert paper["quality_tier"] == "High"
+        assert "Social Media" in paper["osint_source"]

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,90 @@
+from alex.utils.scoring import venue_score, citation_score, institution_score, usage_score, relevance_score
+
+
+class TestVenueScore:
+    def test_whitelisted_venue(self):
+        assert venue_score("IEEE Security & Privacy", ["IEEE", "ACM"]) == 1.0
+
+    def test_non_whitelisted_venue(self):
+        assert venue_score("Unknown Journal", ["IEEE", "ACM"]) == 0.4
+
+    def test_empty_venue(self):
+        assert venue_score("", ["IEEE"]) == 0.2
+
+    def test_none_venue(self):
+        assert venue_score(None, ["IEEE"]) == 0.2
+
+    def test_case_insensitive(self):
+        assert venue_score("ieee transactions", ["IEEE"]) == 1.0
+
+
+class TestCitationScore:
+    def test_zero_citations(self):
+        assert citation_score(0, 2020) == 0.0
+
+    def test_none_citations(self):
+        assert citation_score(None, 2020) == 0.0
+
+    def test_high_citations_recent(self):
+        score = citation_score(500, 2024)
+        assert 0.5 < score <= 1.0
+
+    def test_no_year(self):
+        score = citation_score(10, None)
+        assert 0.0 < score < 1.0
+
+    def test_capped_at_one(self):
+        assert citation_score(100000, 2025) <= 1.0
+
+
+class TestInstitutionScore:
+    def test_university_keyword(self):
+        assert institution_score("John Smith; University of Cambridge") == 0.8
+
+    def test_no_keywords(self):
+        assert institution_score("John Rogers; Jane Doe") == 0.4
+
+    def test_empty(self):
+        assert institution_score("") == 0.2
+
+    def test_none(self):
+        assert institution_score(None) == 0.2
+
+    def test_mit(self):
+        assert institution_score("Researcher at MIT") == 0.8
+
+
+class TestUsageScore:
+    def test_no_data(self):
+        assert usage_score() == 0.0
+
+    def test_downloads_only(self):
+        assert usage_score(downloads=500) == 0.5
+
+    def test_all_metrics(self):
+        score = usage_score(downloads=1000, stars=500, altmetric=100)
+        assert score == 1.0
+
+    def test_capped(self):
+        assert usage_score(downloads=99999) == 1.0
+
+
+class TestRelevanceScore:
+    def test_all_queries_match(self):
+        queries = ["OSINT", "cybersecurity"]
+        score = relevance_score("OSINT cybersecurity paper", "", queries)
+        assert score == 1.0
+
+    def test_no_matches(self):
+        queries = ["OSINT", "cybersecurity"]
+        score = relevance_score("cooking recipes", "", queries)
+        assert score == 0.0
+
+    def test_partial_match(self):
+        queries = ["OSINT", "cybersecurity", "APT", "dark web",
+                   "threat intelligence", "digital investigation", "cybercrime", "online threats"]
+        score = relevance_score("OSINT research", "", queries)
+        assert 0.0 < score < 1.0  # 1 hit / max(1, 8/4) = 1/2 = 0.5
+
+    def test_empty_title_and_abstract(self):
+        assert relevance_score("", "", ["OSINT"]) == 0.0

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,0 +1,80 @@
+from alex.utils.text import clean, normalize_title, unique_keep, split_multi, strip_html_tags
+
+
+class TestClean:
+    def test_none_returns_empty(self):
+        assert clean(None) == ""
+
+    def test_collapses_whitespace(self):
+        assert clean("  hello   world  ") == "hello world"
+
+    def test_converts_to_string(self):
+        assert clean(42) == "42"
+
+    def test_empty_string(self):
+        assert clean("") == ""
+
+
+class TestNormalizeTitle:
+    def test_lowercases(self):
+        assert normalize_title("OSINT Methods") == "osint methods"
+
+    def test_strips_arxiv(self):
+        assert normalize_title("arXiv paper on OSINT") == "paper on osint"
+
+    def test_strips_punctuation(self):
+        assert normalize_title("Hello, World! (2024)") == "hello world 2024"
+
+    def test_empty(self):
+        assert normalize_title("") == ""
+
+    def test_collapses_spaces(self):
+        assert normalize_title("A    B") == "a b"
+
+
+class TestUniqueKeep:
+    def test_deduplicates_case_insensitive(self):
+        assert unique_keep(["Foo", "foo", "FOO"]) == ["Foo"]
+
+    def test_preserves_order(self):
+        assert unique_keep(["b", "a", "c"]) == ["b", "a", "c"]
+
+    def test_skips_empty(self):
+        assert unique_keep(["", "a", "", "b"]) == ["a", "b"]
+
+    def test_empty_input(self):
+        assert unique_keep([]) == []
+
+
+class TestSplitMulti:
+    def test_semicolon(self):
+        assert split_multi("a; b; c") == ["a", "b", "c"]
+
+    def test_comma(self):
+        assert split_multi("a, b, c") == ["a", "b", "c"]
+
+    def test_pipe(self):
+        assert split_multi("a|b|c") == ["a", "b", "c"]
+
+    def test_deduplicates(self):
+        assert split_multi("a; A; b") == ["a", "b"]
+
+    def test_empty(self):
+        assert split_multi("") == []
+
+    def test_none(self):
+        assert split_multi(None) == []
+
+
+class TestStripHtmlTags:
+    def test_strips_html(self):
+        assert strip_html_tags("<p>hello</p>") == "hello"
+
+    def test_strips_jats(self):
+        assert strip_html_tags("<jats:p>hello</jats:p>") == "hello"
+
+    def test_unescapes_entities(self):
+        assert strip_html_tags("&amp; &lt;") == "& <"
+
+    def test_plain_text_unchanged(self):
+        assert strip_html_tags("hello world") == "hello world"


### PR DESCRIPTION
## Summary

Addresses all critical and high-priority findings from a multi-judge codebase critique. 18 commits across 25 files — fixes reliability bugs, adds 74 tests, completes spec gaps, and finishes stub workflows.

- **Fix permanent negative caching** in HttpClient — transient API failures (429, timeout) no longer poison the cache forever
- **Fix silent error swallowing** — bare `except Exception: pass` replaced with specific catches + logging
- **Fix classify.py crashes** — `json.loads()` and `float()` wrapped with error handling and fallback defaults
- **Fix placeholder titles** in citation chaining — Semantic Scholar paper IDs now resolve to real metadata
- **Add Quality_Tier** to LLM classification prompt, extraction, and published JSON (spec requirement)
- **Add candidate_id + timestamp** to quality gate output (spec requirement)
- **Make discovery incremental** — merges new candidates with existing instead of overwriting
- **Sort citation chaining** by citation count before head(100) cutoff
- **Add 74 tests** across 5 files (text, scoring, HTTP caching, connectors, pipeline integration)
- **Configure structured logging** at CLI entry point
- **Complete 4 stub workflows** (discover_manual_assist, tag_new_papers, rebuild_site, harvest_all)
- **Extract OpenAlex field accessors** — eliminate duplicated nested dict traversal across 3 files
- **Add schema validation** at pipeline stage boundaries

### E2E verified
Full pipeline (discover → chain → score → harvest → classify → publish) tested end-to-end. Error handling confirmed working — Semantic Scholar and CORE 429 rate limits were hit during testing but pipeline completed without crashes, errors were logged, and failed requests were NOT cached.

## Test plan

- [x] `python -m pytest tests/ -v` — 74 tests pass
- [x] `python -m alex.cli discover` — 1187 candidates, graceful degradation on 429s
- [x] `python -m alex.cli chain` — citation chaining with real metadata resolution
- [x] `python -m alex.cli score` — routing with candidate_id, scored_at, all 5 score dimensions
- [x] `python -m alex.cli harvest` — Crossref → OpenAlex fallback chain working
- [x] `python -m alex.cli classify` — Quality_Tier + Seminal_Flag present (fallback mode without API key)
- [x] `python -m alex.cli publish` — papers.json includes seminal boolean + quality_tier
- [x] All imports verified: `from alex.pipelines import ...` and `from alex.connectors import ...`

## Follow-up issues

- #1 — Semantic Scholar API key + per-connector rate limiting
- #2 — Make validate_columns raise on critical missing columns
- #3 — Add pipeline tests for classify and harvest
- #4 — Add get_raw() to HttpClient for XML APIs
- #5 — Fix reference_count type inconsistency
- #6 — Guard against NaN titles in discovery seen-set
- #7 — Switch arXiv to RSS feeds to avoid rate limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)