### PR TITLE
Fix validate_columns, add get_raw(), add classify/harvest tests

### DIFF
--- a/alex/utils/http.py
+++ b/alex/utils/http.py
@@ -36,6 +36,30 @@ class HttpClient:
     def _save_cache(self) -> None:
         CACHE.write_text(json.dumps(self.cache, ensure_ascii=False, indent=2), encoding="utf-8")
 
+    def get_raw(
+        self,
+        url: str,
+        params: Optional[dict[str, Any]] = None,
+        headers: Optional[dict[str, str]] = None,
+        timeout: int = 30,
+    ) -> str | None:
+        """HTTP GET returning raw response text. Cached, rate-limited, logged on failure."""
+        key = json.dumps({"url": url, "params": params or {}, "headers": headers or {}, "_raw": True}, sort_keys=True)
+        if key in self.cache:
+            return self.cache[key]
+        try:
+            r = self.session.get(url, params=params, headers=headers, timeout=timeout)
+            r.raise_for_status()
+            text = r.text
+            self.cache[key] = text
+            self._save_cache()
+            return text
+        except requests.exceptions.RequestException as exc:
+            logger.warning("HTTP request failed for %s: %s", url, exc)
+            return None
+        finally:
+            time.sleep(0.5)
+
     def get_json(
         self,
         url: str,

--- a/alex/utils/io.py
+++ b/alex/utils/io.py
@@ -36,8 +36,15 @@ def root_file(*parts: str) -> Path:
     return ROOT.joinpath(*parts)
 
 
-def validate_columns(df: pd.DataFrame, required: list[str], context: str = "") -> None:
-    """Log a warning if the DataFrame is missing expected columns."""
+def validate_columns(df: pd.DataFrame, required: list[str], context: str = "") -> list[str]:
+    """Check that a DataFrame has all required columns.
+
+    Returns the list of missing column names (empty if all present).
+    Raises ValueError if any are missing.
+    """
     missing = [c for c in required if c not in df.columns]
     if missing:
-        logger.warning("Missing columns in %s: %s", context or "DataFrame", missing)
+        msg = f"Missing columns in {context or 'DataFrame'}: {missing}"
+        logger.error(msg)
+        raise ValueError(msg)
+    return missing

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -95,3 +95,49 @@ class TestHttpClientCache:
                 result = client.get_json("https://example.com/api")
             assert result is None
             assert len(client.cache) == 0
+
+
+class TestGetRaw:
+    def test_returns_text_and_caches(self, tmp_path):
+        cache_path = tmp_path / ".alex_cache.json"
+        with patch("alex.utils.http.CACHE", cache_path), \
+             patch("alex.utils.http.time.sleep"):
+            client = HttpClient()
+            mock_resp = MagicMock()
+            mock_resp.text = "<rss><channel></channel></rss>"
+            mock_resp.raise_for_status = MagicMock()
+            with patch.object(client.session, "get", return_value=mock_resp):
+                result = client.get_raw("https://example.com/rss")
+            assert result == "<rss><channel></channel></rss>"
+            # Second call hits cache
+            with patch.object(client.session, "get") as mock_get:
+                result2 = client.get_raw("https://example.com/rss")
+                mock_get.assert_not_called()
+            assert result2 == "<rss><channel></channel></rss>"
+
+    def test_failure_returns_none_not_cached(self, tmp_path):
+        cache_path = tmp_path / ".alex_cache.json"
+        with patch("alex.utils.http.CACHE", cache_path), \
+             patch("alex.utils.http.time.sleep"):
+            client = HttpClient()
+            import requests as req
+            with patch.object(client.session, "get", side_effect=req.exceptions.ConnectionError("fail")):
+                result = client.get_raw("https://example.com/rss")
+            assert result is None
+            assert len(client.cache) == 0
+
+    def test_cache_key_distinct_from_get_json(self, tmp_path):
+        cache_path = tmp_path / ".alex_cache.json"
+        with patch("alex.utils.http.CACHE", cache_path), \
+             patch("alex.utils.http.time.sleep"):
+            client = HttpClient()
+            mock_resp = MagicMock()
+            mock_resp.text = "raw text"
+            mock_resp.raise_for_status = MagicMock()
+            mock_resp.json.return_value = {"json": True}
+            with patch.object(client.session, "get", return_value=mock_resp):
+                raw = client.get_raw("https://example.com/api")
+                js = client.get_json("https://example.com/api")
+            assert raw == "raw text"
+            assert js == {"json": True}
+            assert len(client.cache) == 2

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -1,7 +1,9 @@
 import json
+import pytest
 from unittest.mock import patch
 import pandas as pd
 from alex.pipelines import quality_gate, publish
+from alex.utils.io import validate_columns
 
 
 class TestQualityGate:
@@ -80,3 +82,23 @@ class TestPublish:
         assert paper["seminal"] is True
         assert paper["quality_tier"] == "High"
         assert "Social Media" in paper["osint_source"]
+
+
+class TestValidateColumns:
+    def test_all_columns_present(self):
+        df = pd.DataFrame({"title": ["x"], "authors": ["y"]})
+        assert validate_columns(df, ["title", "authors"]) == []
+
+    def test_missing_columns_raises(self):
+        df = pd.DataFrame({"title": ["x"]})
+        with pytest.raises(ValueError, match="Missing columns.*authors"):
+            validate_columns(df, ["title", "authors"], "test.csv")
+
+    def test_empty_required_list(self):
+        df = pd.DataFrame({"title": ["x"]})
+        assert validate_columns(df, []) == []
+
+    def test_context_in_error_message(self):
+        df = pd.DataFrame()
+        with pytest.raises(ValueError, match="my_file.csv"):
+            validate_columns(df, ["col"], "my_file.csv")

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -1,5 +1,4 @@
 import json
-import os
 import pytest
 from unittest.mock import patch
 import pandas as pd

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -1,4 +1,5 @@
 import json
+import os
 import pytest
 from unittest.mock import patch
 import pandas as pd
@@ -102,3 +103,188 @@ class TestValidateColumns:
         df = pd.DataFrame()
         with pytest.raises(ValueError, match="my_file.csv"):
             validate_columns(df, ["col"], "my_file.csv")
+
+
+class TestClassify:
+    def test_classify_with_no_api_key_uses_fallback(self, tmp_path):
+        """Without OPENAI_API_KEY, classify uses fallback defaults."""
+        harvested = pd.DataFrame([{
+            "title": "OSINT Methods for Cyber Investigations",
+            "authors": "Alice Smith",
+            "year": "2024",
+            "venue": "IEEE S&P",
+            "doi": "10.1234/test",
+            "abstract": "A paper about open source intelligence.",
+            "source_url": "https://example.com",
+            "citation_count": 600,
+            "reference_count": 10,
+        }])
+        (tmp_path / "data").mkdir(parents=True)
+        harvested.to_csv(tmp_path / "data" / "accepted_harvested.csv", index=False)
+
+        with patch("alex.utils.io.ROOT", tmp_path), \
+             patch("alex.utils.io.DATA_DIR", tmp_path / "data"), \
+             patch("alex.utils.io.CONFIG_DIR", tmp_path / "config"), \
+             patch.dict("os.environ", {"OPENAI_API_KEY": ""}, clear=False):
+            from alex.pipelines import classify
+            classify.run()
+
+        result = pd.read_csv(tmp_path / "data" / "accepted_classified.csv")
+        assert len(result) == 1
+        assert result.iloc[0]["Category"] == "Other"
+        assert result.iloc[0]["Quality_Tier"] == "Standard"
+        # 600 citations >= 500 threshold
+        assert str(result.iloc[0]["Seminal_Flag"]).upper() == "TRUE"
+
+    def test_classify_with_mocked_openai(self, tmp_path):
+        """With a mocked OpenAI response, classify populates fields correctly."""
+        harvested = pd.DataFrame([{
+            "title": "Dark Web OSINT",
+            "authors": "Bob Jones",
+            "year": "2023",
+            "venue": "USENIX",
+            "doi": "",
+            "abstract": "Investigating dark web marketplaces.",
+            "source_url": "https://example.com",
+            "citation_count": 10,
+            "reference_count": 5,
+        }])
+        (tmp_path / "data").mkdir(parents=True)
+        harvested.to_csv(tmp_path / "data" / "accepted_harvested.csv", index=False)
+
+        mock_llm_response = {
+            "Category": "Digital Forensics",
+            "Investigation_Type": "Dark Web Analysis",
+            "OSINT_Source_Types": ["Dark Web", "Public Records"],
+            "Keywords": ["dark web", "marketplace"],
+            "Tags": ["forensics"],
+            "Quality_Tier": "High",
+        }
+
+        with patch("alex.utils.io.ROOT", tmp_path), \
+             patch("alex.utils.io.DATA_DIR", tmp_path / "data"), \
+             patch("alex.utils.io.CONFIG_DIR", tmp_path / "config"), \
+             patch("alex.pipelines.classify.call_openai", return_value=mock_llm_response):
+            from alex.pipelines import classify
+            classify.run()
+
+        result = pd.read_csv(tmp_path / "data" / "accepted_classified.csv")
+        assert len(result) == 1
+        assert result.iloc[0]["Category"] == "Digital Forensics"
+        assert result.iloc[0]["Investigation_Type"] == "Dark Web Analysis"
+        assert result.iloc[0]["Quality_Tier"] == "High"
+        assert "Dark Web" in result.iloc[0]["OSINT_Source_Types"]
+
+    def test_classify_missing_columns_raises(self, tmp_path):
+        """Missing required columns should raise ValueError."""
+        bad_df = pd.DataFrame([{"title": "Test"}])  # missing abstract, venue, authors, citation_count
+        (tmp_path / "data").mkdir(parents=True)
+        bad_df.to_csv(tmp_path / "data" / "accepted_harvested.csv", index=False)
+
+        with patch("alex.utils.io.ROOT", tmp_path), \
+             patch("alex.utils.io.DATA_DIR", tmp_path / "data"), \
+             patch("alex.utils.io.CONFIG_DIR", tmp_path / "config"):
+            from alex.pipelines import classify
+            with pytest.raises(ValueError, match="Missing columns"):
+                classify.run()
+
+
+class TestHarvest:
+    def test_harvest_crossref_fallback(self, tmp_path):
+        """Harvest enriches papers via Crossref when DOI is present."""
+        accepted = pd.DataFrame([{
+            "title": "Test Paper",
+            "authors": "Original Author",
+            "year": "2024",
+            "venue": "",
+            "doi": "10.1234/test",
+            "abstract": "",
+            "source_url": "",
+            "citation_count": 0,
+            "reference_count": 0,
+        }])
+        (tmp_path / "data").mkdir(parents=True)
+        accepted.to_csv(tmp_path / "data" / "accepted_candidates.csv", index=False)
+
+        mock_crossref = {
+            "DOI": "10.1234/test",
+            "URL": "https://doi.org/10.1234/test",
+            "container-title": ["IEEE S&P"],
+            "author": [{"given": "Alice", "family": "Smith"}],
+            "abstract": "<p>Enriched abstract from Crossref.</p>",
+        }
+
+        with patch("alex.utils.io.ROOT", tmp_path), \
+             patch("alex.utils.io.DATA_DIR", tmp_path / "data"), \
+             patch("alex.utils.io.CONFIG_DIR", tmp_path / "config"), \
+             patch("alex.connectors.crossref.get_by_doi", return_value=mock_crossref), \
+             patch("alex.pipelines.harvest.HttpClient"):
+            from alex.pipelines import harvest
+            harvest.run()
+
+        result = pd.read_csv(tmp_path / "data" / "accepted_harvested.csv")
+        assert len(result) == 1
+        assert result.iloc[0]["venue"] == "IEEE S&P"
+        assert result.iloc[0]["authors"] == "Alice Smith"
+        assert "Enriched abstract" in result.iloc[0]["abstract"]
+        assert result.iloc[0]["harvest_source"] == "Crossref DOI"
+
+    def test_harvest_openalex_fallback_when_no_abstract(self, tmp_path):
+        """When Crossref has no abstract, harvest falls through to OpenAlex."""
+        accepted = pd.DataFrame([{
+            "title": "Test Paper No DOI",
+            "authors": "",
+            "year": "2023",
+            "venue": "",
+            "doi": "",
+            "abstract": "",
+            "source_url": "",
+            "citation_count": 0,
+            "reference_count": 0,
+        }])
+        (tmp_path / "data").mkdir(parents=True)
+        # Write with empty-string preservation to avoid NaN round-trip issues
+        accepted.to_csv(tmp_path / "data" / "accepted_candidates.csv", index=False)
+
+        mock_oa_work = {
+            "primary_location": {
+                "source": {"display_name": "OpenAlex Venue"},
+                "landing_page_url": "https://openalex.org/W123",
+            },
+            "ids": {"doi": "https://doi.org/10.5678/oa"},
+            "cited_by_count": 42,
+            "referenced_works": ["W1", "W2"],
+        }
+
+        def _load_accepted(path):
+            """Read CSV preserving empty strings instead of NaN."""
+            return pd.read_csv(path, keep_default_na=False)
+
+        with patch("alex.utils.io.ROOT", tmp_path), \
+             patch("alex.utils.io.DATA_DIR", tmp_path / "data"), \
+             patch("alex.utils.io.CONFIG_DIR", tmp_path / "config"), \
+             patch("alex.pipelines.harvest.load_df", side_effect=_load_accepted), \
+             patch("alex.connectors.crossref.get_by_doi", return_value=None), \
+             patch("alex.connectors.openalex.search", return_value=[mock_oa_work]), \
+             patch("alex.connectors.semantic_scholar.search", return_value=[]), \
+             patch("alex.pipelines.harvest.HttpClient"):
+            from alex.pipelines import harvest
+            harvest.run()
+
+        result = pd.read_csv(tmp_path / "data" / "accepted_harvested.csv")
+        assert len(result) == 1
+        assert result.iloc[0]["venue"] == "OpenAlex Venue"
+        assert result.iloc[0]["citation_count"] == 42
+
+    def test_harvest_missing_columns_raises(self, tmp_path):
+        """Missing required columns should raise ValueError."""
+        bad_df = pd.DataFrame([{"title": "Test"}])
+        (tmp_path / "data").mkdir(parents=True)
+        bad_df.to_csv(tmp_path / "data" / "accepted_candidates.csv", index=False)
+
+        with patch("alex.utils.io.ROOT", tmp_path), \
+             patch("alex.utils.io.DATA_DIR", tmp_path / "data"), \
+             patch("alex.utils.io.CONFIG_DIR", tmp_path / "config"):
+            from alex.pipelines import harvest
+            with pytest.raises(ValueError, match="Missing columns"):
+                harvest.run()


### PR DESCRIPTION
## Summary

- **`validate_columns` now raises `ValueError`** on missing columns instead of just logging — pipelines fail fast with clear errors instead of cryptic `KeyError` later (closes #2)
- **`HttpClient.get_raw()`** added for XML/text APIs — cached, rate-limited, logged, with distinct cache keys from `get_json()` (closes #4)
- **Classify and harvest pipeline tests** added with mocked HTTP — covers fallback behavior, OpenAI integration, Crossref/OpenAlex fallback chain, and schema validation (closes #3)

## Test plan

- [x] 112 tests pass (`python -m pytest tests/ -v`)
- [x] `validate_columns` raises on missing columns (4 new tests)
- [x] `get_raw()` caches text, handles failures, uses distinct cache keys (3 new tests)
- [x] Classify: fallback mode, mocked OpenAI, missing columns (3 new tests)
- [x] Harvest: Crossref enrichment, OpenAlex fallback, missing columns (3 new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)