### PR TITLE
Fix reference_count type and NaN title guard

### DIFF
--- a/alex/pipelines/citation_chain.py
+++ b/alex/pipelines/citation_chain.py
@@ -72,7 +72,7 @@ def run() -> None:
                         "discovery_query": title,
                         "inclusion_path": "backward chaining",
                         "citation_count": paper.get("citationCount", 0),
-                        "reference_count": "",
+                        "reference_count": 0,
                     })
 
     if rows:

--- a/alex/pipelines/discovery.py
+++ b/alex/pipelines/discovery.py
@@ -18,7 +18,7 @@ def run() -> None:
     if not existing_df.empty:
         for t in existing_df["title"].tolist():
             key = normalize_title(str(t))
-            if key:
+            if key and key != "nan":
                 seen.add(key)
 
     def add_row(title: str, source: str, **kwargs):


### PR DESCRIPTION
## Summary

Two one-line fixes:

- **reference_count `""` → `0`** in citation_chain.py backward chaining — fixes type inconsistency where OpenAlex rows use integers but Semantic Scholar rows used empty strings (closes #5)
- **NaN title guard** in discovery.py — prevents `str(NaN)` normalizing to `"nan"` and colliding in the seen-set, which could silently skip real papers (closes #6)

## Test plan

- [x] 112 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)