### PR TITLE
fix: coerce NaN to empty string in publish.py JSON output

### DIFF
--- a/alex/pipelines/publish.py
+++ b/alex/pipelines/publish.py
@@ -8,6 +8,10 @@ def run() -> None:
         print("No classified accepted corpus to publish.")
         return
 
+    # Pandas reads empty CSV cells as NaN, which json.dumps would emit as
+    # literal `NaN` (invalid JSON). Coerce to empty strings before export.
+    df = df.fillna("")
+
     public = df.copy()
     save_df(root_file("data", "osint_cyber_papers.csv"), public)
 

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -83,6 +83,31 @@ class TestPublish:
         assert paper["quality_tier"] == "High"
         assert "Social Media" in paper["osint_source"]
 
+    def test_json_output_is_valid_when_fields_are_missing(self, tmp_path):
+        # Empty CSV cells become NaN in pandas; without coercion,
+        # json.dumps emits literal `NaN` and the site fails to parse.
+        classified = pd.DataFrame([{
+            "title": "Sparse Paper", "authors": "", "year": "",
+            "venue": "", "doi": "", "abstract": "", "source_url": "",
+            "Category": "", "Investigation_Type": "",
+            "OSINT_Source_Types": "", "Keywords": "", "Tags": "",
+            "Seminal_Flag": "", "Quality_Tier": "",
+        }])
+        classified_path = tmp_path / "data" / "accepted_classified.csv"
+        classified_path.parent.mkdir(parents=True)
+        classified.to_csv(classified_path, index=False)
+
+        with patch("alex.utils.io.ROOT", tmp_path), \
+             patch("alex.utils.io.DATA_DIR", tmp_path / "data"), \
+             patch("alex.utils.io.CONFIG_DIR", tmp_path / "config"):
+            publish.run()
+
+        raw = (tmp_path / "data" / "papers.json").read_text()
+        assert "NaN" not in raw
+        papers = json.loads(raw)
+        assert papers[0]["title"] == "Sparse Paper"
+        assert papers[0]["seminal"] is False
+
 
 class TestValidateColumns:
     def test_all_columns_present(self):


### PR DESCRIPTION
## Summary
- `publish.py` was emitting literal `NaN` tokens in `papers.json` whenever a source row had missing fields, because pandas reads empty CSV cells as NaN and `json.dumps` serialises NaN by default.
- The frontend then fails to parse the JSON and the site shows *Loading papers…* forever.
- Latent bug: never caught because the pipeline has not run end-to-end against real data where missing fields are normal.

## Fix
- `df.fillna("")` after loading `accepted_classified.csv` so every field serialises as a clean empty string when absent.
- Regression test: loads a deliberately sparse row, asserts `NaN` does not appear in the rendered `papers.json`, and confirms the JSON parses.

## Test plan
- [x] `pytest` — 113 tests pass (including the new regression test)
- [ ] Reviewer: confirm the fillna behaviour is acceptable for the CSV pass-through (`data/osint_cyber_papers.csv`) — numeric columns become object dtype, which is harmless for a download artifact but worth noting

🤖 Generated with [Claude Code](https://claude.com/claude-code)