### PR TITLE
workflows: add concurrency guards to writing workflows (closes #14)

### DIFF
--- a/.github/workflows/citation_chain.yml
+++ b/.github/workflows/citation_chain.yml
@@ -6,6 +6,9 @@ on:
     types: [completed]
 permissions:
   contents: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   chain:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}

--- a/.github/workflows/classify.yml
+++ b/.github/workflows/classify.yml
@@ -6,6 +6,9 @@ on:
     types: [completed]
 permissions:
   contents: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   classify:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}

--- a/.github/workflows/discover.yml
+++ b/.github/workflows/discover.yml
@@ -5,6 +5,9 @@ on:
     - cron: "23 3 * * 1"
 permissions:
   contents: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   discover:
     runs-on: ubuntu-latest

--- a/.github/workflows/harvest.yml
+++ b/.github/workflows/harvest.yml
@@ -3,6 +3,9 @@ on:
   workflow_dispatch:
 permissions:
   contents: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   harvest:
     runs-on: ubuntu-latest

--- a/.github/workflows/harvest_all.yml
+++ b/.github/workflows/harvest_all.yml
@@ -5,6 +5,9 @@ on:
     - cron: '31 3 * * 0'
 permissions:
   contents: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   harvest:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,9 @@ on:
     types: [completed]
 permissions:
   contents: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   publish:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}

--- a/.github/workflows/quality_gate.yml
+++ b/.github/workflows/quality_gate.yml
@@ -6,6 +6,9 @@ on:
     types: [completed]
 permissions:
   contents: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   score:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}

--- a/.github/workflows/rebuild_site.yml
+++ b/.github/workflows/rebuild_site.yml
@@ -3,6 +3,9 @@ on:
   workflow_dispatch:
 permissions:
   contents: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   rebuild:
     runs-on: ubuntu-latest

--- a/.github/workflows/tag_new_papers.yml
+++ b/.github/workflows/tag_new_papers.yml
@@ -3,6 +3,9 @@ on:
   workflow_dispatch:
 permissions:
   contents: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   tag:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Nine workflows end with `git push` on `main`. Overlapping runs can race on the push, leaving one run failing with a non-fast-forward error. Adds the same `concurrency:` block to each.

## Pattern
```yaml
concurrency:
  group: \${{ github.workflow }}-\${{ github.ref }}
  cancel-in-progress: false
```

- **Group scoped to workflow+ref** so separate pipeline stages can still run in parallel (they write different files). Only two runs of the *same* workflow are serialised.
- **`cancel-in-progress: false`** — queue rather than abort. Pipeline stages call paid APIs (OpenAI in `classify` / `tag_new_papers`) and long-running network fetches (`harvest`); aborting a partial run wastes cost.

## Applied to
`citation_chain`, `classify`, `discover`, `harvest`, `harvest_all`, `publish`, `quality_gate`, `rebuild_site`, `tag_new_papers`.

## Intentionally NOT applied
- `discover_manual_assist.yml` — does not push to main.
- `pages.yml` — deploys to the `github-pages` environment, not `main`. It has its own concurrency story (GitHub's Pages deploy action handles it), worth a separate discussion if desired.

## Test plan
- [x] `python3 -c "import yaml; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"` — all 11 YAMLs parse.
- [ ] Reviewer: confirm `cancel-in-progress: false` (queue) is the desired semantics. If you'd rather cancel stale runs (e.g. for `discover` where a fresh run is more useful than finishing an old one), switch that one to `true`.
- [ ] After merge: trigger two manual dispatches of the same workflow back-to-back; confirm the second queues instead of racing.

## Behaviour change in one scenario worth calling out
If workflow A is running and someone manually dispatches A again, the new run will queue behind the first. Previously it would have started immediately and potentially raced on push. This is the intended fix, but it means manual re-dispatches no longer "start right away."

🤖 Generated with [Claude Code](https://claude.com/claude-code)