### PR TITLE
pages/cache: tighten deploy artifact + unify cache policy (closes #13, closes #21)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,6 +7,9 @@ permissions:
   contents: read
   pages: write
   id-token: write
+concurrency:
+  group: pages
+  cancel-in-progress: false
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -14,8 +17,14 @@ jobs:
       name: github-pages
     steps:
       - uses: actions/checkout@v4
+      - name: Stage site files
+        run: |
+          mkdir -p _site/data
+          cp index.html _site/
+          cp data/papers.json _site/data/
+          cp data/osint_cyber_papers.csv _site/data/
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: .
+          path: _site
       - uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 
 # Alex cache
 .alex_cache.json
+.harvest_cache.json
 
 # Planning and execution artifacts (local only)
 docs/superpowers/


### PR DESCRIPTION
Bundles two related Pages changes: closes #13 and #21.

## 1. Pages artifact tightening (#13 part 1)
`pages.yml` previously uploaded `path: .`, so the public site URL was serving the entire repo:
- 4.3 MB `.harvest_cache.json` (local HTTP cache)
- `osint_cyber_paper_library_206_v7_enriched.xlsx` (xlsx seed)
- All Python source under `alex/`
- The test suite under `tests/`
- `docs/`, `scripts/`, etc.

Only three files are actually served by the site: `index.html`, `data/papers.json`, `data/osint_cyber_papers.csv`.

**Fix:** a new *Stage site files* step copies those three into `_site/`, and the upload path changes to `_site`. Verified locally — site renders 206 papers from the 492 KB staged tree, CSV/JSON download links resolve.

```yaml
- name: Stage site files
  run: |
    mkdir -p _site/data
    cp index.html _site/
    cp data/papers.json _site/data/
    cp data/osint_cyber_papers.csv _site/data/
- uses: actions/upload-pages-artifact@v3
  with:
    path: _site
```

## 2. Cache-file policy (#13 part 2)
`.alex_cache.json` was already gitignored; `.harvest_cache.json` (4.3 MB) was committed. Same kind of artifact (HTTP response cache), inconsistent treatment.

**Fix:** gitignore `.harvest_cache.json`, untrack the committed copy with `git rm --cached` (file kept locally for cache warmth). Going forward neither cache ever hits the repo.

**Note:** old blobs of `.harvest_cache.json` remain in git history and still bloat clone size. A `git filter-repo` pass to excise them is out of scope here — file a follow-up if desired.

## 3. Pages concurrency guard (closes #21)
```yaml
concurrency:
  group: pages
  cancel-in-progress: false
```
Two rapid pushes to `main` would otherwise trigger two overlapping Pages deploys that race on the `github-pages` environment. Queue semantics so an in-flight deploy isn't half-torn-down mid-API-call.

## Test plan
- [x] YAML validation of pages.yml (via `yaml.safe_load`).
- [x] Local simulation of the stage-and-serve logic: 206 papers render, CSV and JSON download links work, no console errors.
- [ ] After merge: confirm the public Pages URL no longer serves `alex/*.py`, `tests/*.py`, `.harvest_cache.json`, or the xlsx source.
- [ ] After merge: two back-to-back pushes to main produce serial Pages deploys (not overlapping).

## Risk
- The `_site/` staging is additive — no existing files are modified. Worst case (if the stage step fails) deploy fails cleanly instead of publishing stale or wrong content.
- Removing `.harvest_cache.json` from tracking has no runtime effect; the harvester regenerates it on first run and keeps it across local runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)