### PR TITLE
workflows: map existing OPEN_API_KEY secret to OPENAI_API_KEY env

### DIFF
--- a/.github/workflows/classify.yml
+++ b/.github/workflows/classify.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: "3.11"
       - run: pip install -r requirements.txt
       - env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPEN_API_KEY }}
           OPENAI_MODEL: ${{ vars.OPENAI_MODEL || 'gpt-4o-mini' }}
         run: python -m alex.cli classify
       - run: |

--- a/.github/workflows/tag_new_papers.yml
+++ b/.github/workflows/tag_new_papers.yml
@@ -16,7 +16,7 @@ jobs:
           python-version: "3.11"
       - run: pip install -r requirements.txt
       - env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPEN_API_KEY }}
           OPENAI_MODEL: ${{ vars.OPENAI_MODEL || 'gpt-4o-mini' }}
         run: python -m alex.cli classify
       - run: |


### PR DESCRIPTION
## Summary
Two-line fix. The repo secret is stored as `OPEN_API_KEY` (missing the `AI`), but `classify.yml` and `tag_new_papers.yml` reference `secrets.OPENAI_API_KEY`, which always resolves to an empty string. Every classify run to date has silently fallen back to the `FALLBACK` defaults in `classify.py` instead of calling OpenAI — explains why the existing publish/rebuild runs produced no meaningful tags.

## Fix
```diff
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPEN_API_KEY }}
```

Left side stays standard (`OPENAI_API_KEY` is what the OpenAI SDK and `classify.py`'s `os.getenv` expect). Only the right side (the secret lookup) is adjusted to the real name.

## Why not rename the secret?
That requires knowing the key value, which we can't read from GitHub. If/when the key is rotated, the right-hand side can flip back to `OPENAI_API_KEY` at that point for naming hygiene.

## Test plan
- [x] YAML parses.
- [ ] Post-merge: manually dispatch `Classify` (or `Tag new papers`) and confirm from the run log that OpenAI calls are made (visible by timing — real calls take seconds; fallback path is instant).

## Scope
Unblocks meaningful E2E testing of the classify stage. Without this, the full pipeline end-to-end can't exercise the LLM tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)