### PR TITLE
workflows: stop trying to git-add gitignored .alex_cache.json

### DIFF
--- a/.github/workflows/citation_chain.yml
+++ b/.github/workflows/citation_chain.yml
@@ -25,6 +25,6 @@ jobs:
       - run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add data/discovery_candidates.csv .alex_cache.json
+          git add data/discovery_candidates.csv
           git diff --cached --quiet || git commit -m "Citation chain candidates"
           git push

--- a/.github/workflows/discover.yml
+++ b/.github/workflows/discover.yml
@@ -25,6 +25,6 @@ jobs:
       - run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add data/discovery_candidates.csv .alex_cache.json
+          git add data/discovery_candidates.csv
           git diff --cached --quiet || git commit -m "Discover candidates"
           git push

--- a/.github/workflows/harvest.yml
+++ b/.github/workflows/harvest.yml
@@ -21,6 +21,6 @@ jobs:
       - run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add data/accepted_harvested.csv .alex_cache.json
+          git add data/accepted_harvested.csv
           git diff --cached --quiet || git commit -m "Harvest metadata"
           git push


### PR DESCRIPTION
## Summary
Three-line fix across three workflows. **Why the scheduled pipeline has never run end-to-end.**

## Root cause
`discover.yml`, `citation_chain.yml`, and `harvest.yml` all ended their commit step with a line like:

```bash
git add data/<output>.csv .alex_cache.json
```

`.alex_cache.json` is in `.gitignore` (the HTTP response cache — policy is local-only, matching what we just did for `.harvest_cache.json` in #13). So `git add` fails with one of:
- `The following paths are ignored by one of your .gitignore files` (when the cache exists)
- `fatal: pathspec did not match any files` (when it doesn't)

Either way, `bash -e` aborts the step and the workflow reports `failure`. This has probably been broken for every scheduled run that ever made it past API calls.

## Evidence
Found while dispatching `discover` manually to E2E-test PR #25's fix:

```
Run git config user.name "github-actions[bot]"
The following paths are ignored by one of your .gitignore files:
.alex_cache.json
hint: Use -f if you really want to add them.
##[error]Process completed with exit code 1.
```

PR #25's `workflow_run` chaining mechanism was verified to work correctly — Citation chain fired and correctly skipped (since Discover failed). So #25's fix is good; this is a separate latent defect.

## Fix
Drop `.alex_cache.json` from the three `git add` lines. The cache stays in place during the job (it's written by the runner's Python process) and accelerates that single run; we just don't try to persist it across runs via the repo.

```diff
-          git add data/discovery_candidates.csv .alex_cache.json
+          git add data/discovery_candidates.csv
```
(and equivalents in `citation_chain.yml` and `harvest.yml`)

## Test plan
- [x] YAML parses.
- [ ] After merge: dispatch `discover` again; expect it to actually complete and push, then auto-chain through Citation chain → Quality gate.
- [ ] Observe that `.alex_cache.json` is not committed (expected — it's gitignored).

## Trade-off
Each CI run will start with a cold HTTP cache. For discover/citation_chain, that means hitting the polite rate-limited OpenAlex/Crossref/Semantic Scholar endpoints from scratch each time. Acceptable: (a) these endpoints are tolerant with `HARVEST_MAILTO` set, and (b) persisting the cache in git was already causing `.harvest_cache.json` to bloat the repo (#13). If cache warmth in CI becomes important later, the fix is to use `actions/cache@v4`, not to commit the cache file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)