### PR TITLE
pipelines: always write output files on empty input (closes #32)

### DIFF
--- a/alex/pipelines/classify.py
+++ b/alex/pipelines/classify.py
@@ -74,9 +74,13 @@ def call_openai(row: dict) -> dict:
 
 
 def run() -> None:
+    output_path = root_file("data", "accepted_classified.csv")
     df = load_df(root_file("data", "accepted_harvested.csv"))
     if df.empty:
         print("No harvested accepted candidates to classify.")
+        # Write an empty file so downstream workflows can `git add` without
+        # failing; the next stage sees an empty DataFrame and no-ops cleanly.
+        save_df(output_path, pd.DataFrame())
         return
     validate_columns(df, ["title", "abstract", "venue", "authors", "citation_count"], "accepted_harvested.csv")
     rows = []
@@ -97,5 +101,5 @@ def run() -> None:
         out["Quality_Tier"] = tags.get("Quality_Tier", "Standard")
         out["Seminal_Flag"] = "TRUE" if _safe_citation_count(row) >= 500 else "FALSE"
         rows.append(out)
-    save_df(root_file("data", "accepted_classified.csv"), pd.DataFrame(rows))
+    save_df(output_path, pd.DataFrame(rows))
     print(f"Classified {len(rows)} papers")

--- a/alex/pipelines/harvest.py
+++ b/alex/pipelines/harvest.py
@@ -7,9 +7,13 @@ from alex.connectors import crossref, openalex, semantic_scholar
 from alex.utils.text import clean
 
 def run() -> None:
+    output_path = root_file("data", "accepted_harvested.csv")
     df = load_df(root_file("data", "accepted_candidates.csv"))
     if df.empty:
         print("No accepted candidates to harvest.")
+        # Write an empty file so downstream workflows can `git add` without
+        # failing; the next stage sees an empty DataFrame and no-ops cleanly.
+        save_df(output_path, pd.DataFrame())
         return
     validate_columns(df, ["title", "doi", "authors", "venue", "abstract"], "accepted_candidates.csv")
 
@@ -60,5 +64,5 @@ def run() -> None:
 
         harvested.append(best)
 
-    save_df(root_file("data", "accepted_harvested.csv"), pd.DataFrame(harvested))
+    save_df(output_path, pd.DataFrame(harvested))
     print(f"Harvested {len(harvested)} accepted candidates")

--- a/alex/pipelines/publish.py
+++ b/alex/pipelines/publish.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
+import pandas as pd
 from alex.utils.io import load_df, save_df, save_json, root_file
 from alex.utils.text import split_multi
 
 def run() -> None:
+    public_csv = root_file("data", "osint_cyber_papers.csv")
+    papers_json = root_file("data", "papers.json")
     df = load_df(root_file("data", "accepted_classified.csv"))
     if df.empty:
         print("No classified accepted corpus to publish.")
+        # Write empty outputs so downstream workflows can `git add` without
+        # failing. The workflow's `git diff --cached --quiet || commit` guard
+        # means nothing gets committed if content is unchanged.
+        save_df(public_csv, pd.DataFrame())
+        save_json(papers_json, [])
         return
 
     # Pandas reads empty CSV cells as NaN, which json.dumps would emit as
@@ -13,7 +21,7 @@ def run() -> None:
     df = df.fillna("")
 
     public = df.copy()
-    save_df(root_file("data", "osint_cyber_papers.csv"), public)
+    save_df(public_csv, public)
 
     papers = []
     for i, (_, row) in enumerate(public.iterrows()):
@@ -38,5 +46,5 @@ def run() -> None:
             "seminal": str(row.get("Seminal_Flag", "FALSE")).upper() == "TRUE",
             "quality_tier": row.get("Quality_Tier", "Standard"),
         })
-    save_json(root_file("data", "papers.json"), papers)
+    save_json(papers_json, papers)
     print(f"Published {len(papers)} papers")

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -108,6 +108,21 @@ class TestPublish:
         assert papers[0]["title"] == "Sparse Paper"
         assert papers[0]["seminal"] is False
 
+    def test_empty_input_produces_empty_outputs(self, tmp_path):
+        # When accepted_classified.csv is missing (upstream had no data),
+        # publish must still write both output files so the workflow's
+        # `git add` step doesn't abort with "pathspec did not match".
+        (tmp_path / "data").mkdir(parents=True)
+
+        with patch("alex.utils.io.ROOT", tmp_path), \
+             patch("alex.utils.io.DATA_DIR", tmp_path / "data"), \
+             patch("alex.utils.io.CONFIG_DIR", tmp_path / "config"):
+            publish.run()
+
+        assert (tmp_path / "data" / "osint_cyber_papers.csv").exists()
+        assert (tmp_path / "data" / "papers.json").exists()
+        assert json.loads((tmp_path / "data" / "papers.json").read_text()) == []
+
 
 class TestValidateColumns:
     def test_all_columns_present(self):
@@ -212,6 +227,19 @@ class TestClassify:
             with pytest.raises(ValueError, match="Missing columns"):
                 classify.run()
 
+    def test_classify_empty_input_produces_empty_output(self, tmp_path):
+        # Upstream with no work to do must still produce an output file so
+        # the workflow's `git add` doesn't fail with "pathspec did not match".
+        (tmp_path / "data").mkdir(parents=True)
+
+        with patch("alex.utils.io.ROOT", tmp_path), \
+             patch("alex.utils.io.DATA_DIR", tmp_path / "data"), \
+             patch("alex.utils.io.CONFIG_DIR", tmp_path / "config"):
+            from alex.pipelines import classify
+            classify.run()
+
+        assert (tmp_path / "data" / "accepted_classified.csv").exists()
+
 
 class TestHarvest:
     def test_harvest_crossref_fallback(self, tmp_path):
@@ -312,3 +340,16 @@ class TestHarvest:
             from alex.pipelines import harvest
             with pytest.raises(ValueError, match="Missing columns"):
                 harvest.run()
+
+    def test_harvest_empty_input_produces_empty_output(self, tmp_path):
+        # Upstream with no work to do must still produce an output file so
+        # the workflow's `git add` doesn't fail with "pathspec did not match".
+        (tmp_path / "data").mkdir(parents=True)
+
+        with patch("alex.utils.io.ROOT", tmp_path), \
+             patch("alex.utils.io.DATA_DIR", tmp_path / "data"), \
+             patch("alex.utils.io.CONFIG_DIR", tmp_path / "config"):
+            from alex.pipelines import harvest
+            harvest.run()
+
+        assert (tmp_path / "data" / "accepted_harvested.csv").exists()


### PR DESCRIPTION
## Summary
Three-stage fix for the `fatal: pathspec did not match any files` errors that have been turning clean-no-op pipeline runs into `failure` conclusions.

## Root cause
`harvest.py`, `classify.py`, and `publish.py` used an early-return pattern when their upstream input was empty:

```python
df = load_df(...)
if df.empty:
    print("No ... to ...")
    return   # <- output file never created
```

Downstream workflows then aborted their commit step with:

```
fatal: pathspec 'data/accepted_harvested.csv' did not match any files
##[error]Process completed with exit code 128.
```

With `bash -e`, the whole step fails and the run is marked `failure`. First encountered during the real E2E pipeline dispatch on 2026-04-23 when quality_gate accepted 0 of 865 candidates.

## Fix
Each stage now writes an empty output when input is empty:

```python
if df.empty:
    print("No ... to ...")
    save_df(output_path, pd.DataFrame())
    return
```

The workflow's existing `git diff --cached --quiet || commit` guard means no spurious commits — just a successful no-op run end-to-end.

| Stage | Outputs on empty input |
|---|---|
| `harvest.py` | `accepted_harvested.csv` (empty) |
| `classify.py` | `accepted_classified.csv` (empty) |
| `publish.py` | `osint_cyber_papers.csv` (empty) + `papers.json` (`[]`) |

## Test plan
- [x] 3 new regression tests in `test_pipelines.py` — one per stage, verify output file exists after a run with no upstream input.
- [x] All 116 tests pass (was 113).
- [ ] After merge: dispatch `harvest_all` again; verify the chain completes with `success` conclusion on all workflows even if no papers flow through (current state of the corpus).

## Why not just tolerate missing files at the workflow level?
A file-existence guard in the YAML would work but split a contract across two layers. Putting it at the Python stage keeps the invariant "if my stage ran, my output file exists" predictable for anyone reading individual scripts or calling them via `python -m alex.cli ...` outside CI.

## Related
- Earlier this session, a similar-class bug was fixed in PR #27 (workflows tried to `git add .alex_cache.json` which is gitignored).
- Scoring upstream (PR #33) caused the reject rate to rise to 79%, which is what exposed this issue — before that, accepted_candidates.csv was always non-empty so harvest always produced a file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)