### PR TITLE
discovery: enrich missing abstracts via OpenAlex-by-DOI lookup

### DIFF
--- a/alex/pipelines/discovery.py
+++ b/alex/pipelines/discovery.py
@@ -145,6 +145,13 @@ def run() -> None:
             discovery_query="; ".join(item.get("matched_queries", [])),
         )
 
+    # Enrich abstracts at discovery time so quality_gate's relevance scoring
+    # sees full text. Sources like Crossref often omit abstracts from search
+    # results; when a row has a DOI, a follow-up OpenAlex lookup fills the gap
+    # cheaply. Harvest still runs later for authoritative metadata, but it no
+    # longer needs to hunt for abstracts as its primary job.
+    _enrich_missing_abstracts(rows, client, os.getenv("HARVEST_MAILTO", ""))
+
     new_df = pd.DataFrame(rows)
     if not existing_df.empty and not new_df.empty:
         df = pd.concat([existing_df, new_df], ignore_index=True)
@@ -154,3 +161,25 @@ def run() -> None:
         df = existing_df
     save_df(existing_path, df)
     print(f"Discovered {len(rows)} new candidates ({len(df)} total)")
+
+
+def _enrich_missing_abstracts(rows: list[dict], client: HttpClient, mailto: str) -> None:
+    """Fill missing abstracts via an OpenAlex-by-DOI lookup.
+
+    Only targets rows that have a DOI but no abstract. OpenAlex's
+    abstract_inverted_index has broad coverage and the endpoint is polite-API
+    friendly, so this adds at most one extra request per abstract-less row.
+    Mutates rows in place.
+    """
+    enriched = 0
+    for row in rows:
+        if row.get("abstract") or not row.get("doi"):
+            continue
+        work = openalex.get_by_doi(client, row["doi"], mailto)
+        if work:
+            text = openalex.abstract(work)
+            if text:
+                row["abstract"] = text
+                enriched += 1
+    if enriched:
+        print(f"Enriched {enriched} abstracts via OpenAlex DOI lookup")

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -1,6 +1,6 @@
 import json
 import pytest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 import pandas as pd
 from alex.pipelines import quality_gate, publish
 from alex.utils.io import validate_columns
@@ -353,3 +353,36 @@ class TestHarvest:
             harvest.run()
 
         assert (tmp_path / "data" / "accepted_harvested.csv").exists()
+
+
+class TestDiscoveryAbstractEnrichment:
+    def test_enriches_row_missing_abstract_with_doi(self):
+        from alex.pipelines.discovery import _enrich_missing_abstracts
+
+        rows = [
+            {"doi": "10.1234/has-abstract", "abstract": "already present"},
+            {"doi": "10.1234/needs-abstract", "abstract": ""},
+            {"doi": "", "abstract": ""},  # no DOI -> skipped
+        ]
+        mock_work = {"abstract_inverted_index": {"Cybersecurity": [0], "research": [1]}}
+
+        with patch("alex.pipelines.discovery.openalex.get_by_doi",
+                   side_effect=[mock_work]) as mock_get:
+            _enrich_missing_abstracts(rows, client=MagicMock(), mailto="")
+
+        # Only the second row (missing abstract + has DOI) triggers a lookup
+        assert mock_get.call_count == 1
+        assert rows[0]["abstract"] == "already present"  # untouched
+        assert rows[1]["abstract"] == "Cybersecurity research"  # filled
+        assert rows[2]["abstract"] == ""  # skipped (no DOI)
+
+    def test_lookup_returning_no_abstract_leaves_row_unchanged(self):
+        from alex.pipelines.discovery import _enrich_missing_abstracts
+
+        rows = [{"doi": "10.1234/no-abstract-returned", "abstract": ""}]
+
+        with patch("alex.pipelines.discovery.openalex.get_by_doi",
+                   return_value={"abstract_inverted_index": {}}):
+            _enrich_missing_abstracts(rows, client=MagicMock(), mailto="")
+
+        assert rows[0]["abstract"] == ""


### PR DESCRIPTION
## Motivation
`quality_gate` runs before `harvest`, so `relevance_score` only sees abstracts that the primary discovery connector shipped up front. Measured fill-rates on the real 865-paper corpus:

| Source | Fill rate |
|---|---|
| arXiv RSS | 100% |
| Zenodo | 97% |
| Semantic Scholar | 71% |
| **Crossref** | **22%** ← ~130 rows without abstracts |
| OpenAlex | 100% (via PR #33) |

Crossref's search endpoint often omits abstracts even when the paper has one. Those rows then get scored title-only at quality_gate.

## Fix
After all connector loops finish in `discovery.run()`, call a new helper that:
- Iterates rows with a DOI but no abstract
- Does a single `openalex.get_by_doi()` lookup
- Reconstructs the abstract from `abstract_inverted_index` if present
- Leaves the row unchanged otherwise

```python
def _enrich_missing_abstracts(rows, client, mailto):
    for row in rows:
        if row.get("abstract") or not row.get("doi"):
            continue
        work = openalex.get_by_doi(client, row["doi"], mailto)
        if work and (text := openalex.abstract(work)):
            row["abstract"] = text
```

Only one extra API call per abstract-less row, targeted at OpenAlex which has the best combined coverage + polite-API friendliness.

## Why not move more of harvest's logic here?
Harvest does authoritative metadata enrichment on the *post-quality-gate* accepted set (much smaller). Its abstract-hunting is a secondary responsibility — keeping it as a fallback for the smaller accepted set keeps it fast when it matters (discovery runs over the full candidate pool).

## Test plan
- [x] 2 new tests in `TestDiscoveryAbstractEnrichment`: only-missing-with-DOI triggers lookup, lookup returning no abstract leaves row unchanged.
- [x] 118 tests pass (was 116).
- [ ] Post-merge: dispatch `discover`; check abstract fill rate on new `discovery_candidates.csv` — should jump for Crossref rows especially.

## Related
- Closes the discovery-side half of #34's concern (post-harvest re-score still worth doing for the small remaining uncovered set).
- Follow-up to PR #33 (OpenAlex abstract reconstruction at discovery time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)