### PR TITLE
workflows: unify pipeline into one workflow to bypass workflow_run 3-level cap

### DIFF
--- a/.github/workflows/citation_chain.yml
+++ b/.github/workflows/citation_chain.yml
@@ -1,9 +1,6 @@
 name: Citation chain
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Discover"]
-    types: [completed]
 permissions:
   contents: write
 concurrency:

--- a/.github/workflows/classify.yml
+++ b/.github/workflows/classify.yml
@@ -1,9 +1,6 @@
 name: Classify
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Harvest"]
-    types: [completed]
 permissions:
   contents: write
 concurrency:

--- a/.github/workflows/discover.yml
+++ b/.github/workflows/discover.yml
@@ -1,8 +1,6 @@
 name: Discover
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "23 3 * * 1"
 permissions:
   contents: write
 concurrency:

--- a/.github/workflows/harvest.yml
+++ b/.github/workflows/harvest.yml
@@ -1,9 +1,6 @@
 name: Harvest
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Quality gate"]
-    types: [completed]
 permissions:
   contents: write
 concurrency:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,0 +1,97 @@
+name: Pipeline
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "23 3 * * 1"
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+concurrency:
+  group: pipeline
+  cancel-in-progress: false
+jobs:
+  pipeline:
+    # The full chain in one job so all six stages share a single runner.
+    # Each stage commits its own output, preserving a per-stage audit trail
+    # in git history. Running as one job also side-steps the 3-level cap on
+    # workflow_run cascades (we hit this in the split-workflow layout).
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -r requirements.txt
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Discover
+        env:
+          HARVEST_MAILTO: ${{ secrets.HARVEST_MAILTO }}
+          CORE_API_KEY: ${{ secrets.CORE_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python -m alex.cli discover
+          git add data/discovery_candidates.csv
+          git diff --cached --quiet || git commit -m "Discover candidates"
+          git push
+      - name: Citation chain
+        env:
+          HARVEST_MAILTO: ${{ secrets.HARVEST_MAILTO }}
+        run: |
+          python -m alex.cli chain
+          git add data/discovery_candidates.csv
+          git diff --cached --quiet || git commit -m "Citation chain candidates"
+          git push
+      - name: Quality gate
+        run: |
+          python -m alex.cli score
+          git add data/quality_metrics.csv data/review_queue.csv data/rejected_candidates.csv data/accepted_candidates.csv
+          git diff --cached --quiet || git commit -m "Quality gate results"
+          git push
+      - name: Harvest
+        env:
+          HARVEST_MAILTO: ${{ secrets.HARVEST_MAILTO }}
+        run: |
+          python -m alex.cli harvest
+          git add data/accepted_harvested.csv
+          git diff --cached --quiet || git commit -m "Harvest metadata"
+          git push
+      - name: Classify
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPEN_API_KEY }}
+          OPENAI_MODEL: ${{ vars.OPENAI_MODEL || 'gpt-4o-mini' }}
+        run: |
+          python -m alex.cli classify
+          git add data/accepted_classified.csv
+          git diff --cached --quiet || git commit -m "Classify accepted papers"
+          git push
+      - name: Publish
+        run: |
+          python -m alex.cli publish
+          git add data/osint_cyber_papers.csv data/papers.json
+          git diff --cached --quiet || git commit -m "Publish public corpus"
+          git push
+  deploy:
+    # Pages deploy in a separate job so it can run under the github-pages
+    # environment. Checks out main after the pipeline job's pushes so the
+    # published assets are already on disk.
+    needs: pipeline
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+    steps:
+      - uses: actions/checkout@v4
+      - name: Stage site files
+        run: |
+          mkdir -p _site/data
+          cp index.html _site/
+          cp data/papers.json _site/data/
+          cp data/osint_cyber_papers.csv _site/data/
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+      - uses: actions/deploy-pages@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,6 @@
 name: Publish assets
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Classify"]
-    types: [completed]
 permissions:
   contents: write
 concurrency:

--- a/.github/workflows/quality_gate.yml
+++ b/.github/workflows/quality_gate.yml
@@ -1,9 +1,6 @@
 name: Quality gate
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Citation chain"]
-    types: [completed]
 permissions:
   contents: write
 concurrency:

--- a/README.md
+++ b/README.md
@@ -153,40 +153,43 @@ python -m alex.cli publish
 
 ## GitHub Actions included
 
-Pipeline workflows (each commits its output to `main`):
+### Automated
+- **`pipeline.yml`** — scheduled **Mon 03:23 UTC**. A single workflow that runs all six pipeline stages sequentially in one job, then deploys to GitHub Pages as a second job. Uses one runner for all data stages (faster than split workflows and sidesteps GitHub's 3-level `workflow_run` cascade cap).
+- `pages.yml` — GitHub Pages deploy on push to `main`. Covers non-pipeline pushes (e.g. human merges); `pipeline.yml` has its own Pages deploy job for the automated run.
+- `discover_manual_assist.yml` — scheduled Mon 04:05 UTC reminder for human-curated sources (Google Scholar / Dimensions / BASE).
 
-- `discover.yml` — scheduled Mon 03:23 UTC
-- `citation_chain.yml` — chains from Discover
-- `quality_gate.yml` — chains from Citation chain
-- `harvest.yml` — chains from Quality gate
-- `classify.yml` — chains from Harvest
-- `publish.yml` — chains from Classify
-- `tag_new_papers.yml` — manual re-tag via LLM
-- `rebuild_site.yml` — manual re-publish
+### Manual (`workflow_dispatch` only)
+Kept as ad-hoc debug tools that run a single stage:
 
-Deployment and auxiliary:
+- `discover.yml`, `citation_chain.yml`, `quality_gate.yml`, `harvest.yml`, `classify.yml`, `publish.yml`
+- `tag_new_papers.yml` — re-tag already-harvested papers via LLM
+- `rebuild_site.yml` — regenerate site assets from existing classified corpus
 
-- `pages.yml` — GitHub Pages deploy on push to `main`
-- `discover_manual_assist.yml` — scheduled reminder for Google Scholar / Dimensions / BASE
+None of these auto-trigger anything else. Use them when you want to re-run a single stage without walking the whole chain.
 
-### Data flow and cadence
+### Data flow
 
 ```mermaid
 flowchart TB
     classDef cron fill:#fef3c7,stroke:#f59e0b,color:#78350f
-    classDef wf fill:#dbeafe,stroke:#3b82f6,color:#1e3a8a
+    classDef step fill:#dbeafe,stroke:#3b82f6,color:#1e3a8a
     classDef data fill:#ede9fe,stroke:#8b5cf6,color:#4c1d95
     classDef deploy fill:#d1fae5,stroke:#10b981,color:#064e3b
 
     cronMon["⏰ Mon 03:23 UTC"]:::cron
 
-    discover["Discover"]:::wf
-    citation["Citation chain"]:::wf
-    quality["Quality gate"]:::wf
-    harvest["Harvest"]:::wf
-    classify["Classify (LLM)"]:::wf
-    publish["Publish assets"]:::wf
-    pages["Pages deploy"]:::deploy
+    subgraph pipeline_job["pipeline.yml — pipeline job (single runner)"]
+        discover["Discover"]:::step
+        citation["Citation chain"]:::step
+        quality["Quality gate"]:::step
+        harvest["Harvest"]:::step
+        classify["Classify (LLM)"]:::step
+        publish["Publish assets"]:::step
+    end
+
+    subgraph deploy_job["pipeline.yml — deploy job"]
+        pages["Pages deploy"]:::deploy
+    end
 
     dc[("discovery_candidates.csv")]:::data
     ac[("accepted_candidates.csv")]:::data
@@ -195,13 +198,8 @@ flowchart TB
     site[("data/papers.json<br/>data/osint_cyber_papers.csv")]:::data
 
     cronMon --> discover
-
-    discover -- workflow_run --> citation
-    citation -- workflow_run --> quality
-    quality -- workflow_run --> harvest
-    harvest -- workflow_run --> classify
-    classify -- workflow_run --> publish
-    publish -- "git push main" --> pages
+    discover --> citation --> quality --> harvest --> classify --> publish
+    publish -- needs --> pages
 
     discover -.writes.-> dc
     citation -.augments.-> dc
@@ -218,13 +216,9 @@ flowchart TB
 
 **Weekly cycle in practice:**
 
-One cron tick kicks off the whole pipeline. `Discover` fires Monday 03:23 UTC and each stage chains into the next via `workflow_run` on success:
+One cron tick kicks off the whole pipeline. `pipeline.yml` runs every stage sequentially in a single job — each stage commits its output to `main` with a clear message so git log still reads as a per-stage audit trail — then a second job deploys the refreshed site to GitHub Pages.
 
-```
-Discover → Citation chain → Quality gate → Harvest → Classify → Publish → Pages deploy
-```
-
-A full end-to-end run takes roughly 15–30 minutes, driven mostly by API-call volume in `Citation chain` (Semantic Scholar) and `Classify` (OpenAI). The site is refreshed at most once per week on Monday; manual re-runs via `workflow_dispatch` on any stage are available for ad-hoc updates.
+A full end-to-end run takes roughly 15–30 minutes, driven mostly by API-call volume in `Citation chain` (Semantic Scholar) and `Classify` (OpenAI). The site is refreshed at most once per week on Monday; manual re-runs via `workflow_dispatch` on any individual stage workflow are available for ad-hoc updates.
 
 The parallel `Manual-assist discovery queue` reminder fires Monday 04:05 UTC for human curation of Google Scholar / Dimensions / BASE. Candidates added by hand before the following Monday are picked up on the next cycle.
 


### PR DESCRIPTION
## Motivation
The split-workflow chain hit GitHub's documented 3-level `workflow_run` cascade cap, verified definitively by [the GitHub docs](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_run):

> "You can't use `workflow_run` to chain together more than three levels of workflows."

Our chain needs five cascades (Discover → Citation chain → Quality gate → Harvest → Classify → Publish). Today's real run stopped exactly at Harvest — Classify never fired, matching the docs precisely.

## Fix

### New: `pipeline.yml`
Single workflow, two jobs:

1. **`pipeline`** — one runner, six sequential steps (`Discover`/`Citation chain`/`Quality gate`/`Harvest`/`Classify`/`Publish`). Each step runs its CLI command and commits+pushes its own stage output with a stage-specific commit message. Git log still reads as a per-stage audit trail.
2. **`deploy`** — `needs: pipeline`, runs under the `github-pages` environment, stages `index.html` + `data/papers.json` + `data/osint_cyber_papers.csv` into `_site/`, uploads the artifact, deploys via `actions/deploy-pages`.

Triggers: weekly cron `Mon 03:23 UTC` + `workflow_dispatch`. Concurrency group `pipeline` with `cancel-in-progress: false`.

Running as one job (rather than multiple `needs:`-chained jobs) saves ~20–30s of runner startup per stage — ~2–3 minutes total on the full run.

### Individual stage workflows → manual-only
`discover.yml`, `citation_chain.yml`, `quality_gate.yml`, `harvest.yml`, `classify.yml`, `publish.yml` now have **only** `workflow_dispatch`. They remain as ad-hoc debug tools for re-running a single stage without walking the whole chain. The `schedule` + `workflow_run` triggers that drove the old chain are gone.

### Unchanged
- `pages.yml` (push + workflow_dispatch) — still handles non-pipeline pushes (human merges, etc.). The pipeline's own Pages deploy covers the automated path.
- `discover_manual_assist.yml` — Monday reminder for human-curated sources.
- `tag_new_papers.yml`, `rebuild_site.yml` — always were manual.

## Test plan
- [x] YAML validation across all 11 workflows.
- [x] 121 tests pass.
- [ ] After merge: manually dispatch `Pipeline` and confirm all six stages plus Pages deploy complete in one Actions run, with clean per-stage commits on `main`.
- [ ] Confirm the deployed site reflects the latest corpus (no manual intervention needed this time).

## Trade-offs

**Single job vs `needs:`-chained jobs.** I chose single-job to save runner startup time. Downside: if step 3 fails, the job UI shows "job failed at step 3", slightly less discoverable than 6 separate green/red tiles. Steps 1-2's commits are already pushed, so no data loss. Can revisit if the granular UI matters more than the startup time.

**Individual stage workflows kept.** Could also delete them to reduce count. I kept them because they're useful for debugging — `gh workflow run classify.yml` to re-tag without re-running discovery. Can prune later if they go stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)