### PR TITLE
discover: 7-day window + pagination for CORE/Zenodo/GitHub (part 3 of #40)

### DIFF
--- a/alex/connectors/core.py
+++ b/alex/connectors/core.py
@@ -1,10 +1,37 @@
 from __future__ import annotations
 from typing import Any
 from alex.utils.http import HttpClient
+from alex.utils.paginate import paginate
 
 CORE = "https://api.core.ac.uk/v3/search/works"
 
-def search(client: HttpClient, query: str, api_key: str = "", limit: int = 25) -> list[dict[str, Any]]:
+
+def search(
+    client: HttpClient,
+    query: str,
+    api_key: str = "",
+    limit: int = 25,
+    *,
+    from_date: str | None = None,
+    until_date: str | None = None,
+    max_pages: int = 1,
+) -> list[dict[str, Any]]:
+    """Search CORE works.
+
+    Default behaviour (max_pages=1, no date window) preserves the prior
+    single-page fetch. Pass `from_date`/`until_date` (ISO YYYY-MM-DD) to
+    filter by publication date via a range clause in the `q` parameter,
+    and `max_pages > 1` to paginate via `offset`.
+    """
+    q = query
+    if from_date and until_date:
+        q = f"{query} AND publishedDate>={from_date} AND publishedDate<={until_date}"
+
     headers = {"Authorization": f"Bearer {api_key}"} if api_key else None
-    data = client.get_json(CORE, params={"q": query, "limit": limit}, headers=headers)
-    return (data or {}).get("results", [])
+
+    def fetch_page(page_num: int) -> list[dict[str, Any]]:
+        params = {"q": q, "limit": limit, "offset": (page_num - 1) * limit}
+        data = client.get_json(CORE, params=params, headers=headers) or {}
+        return data.get("results", []) or []
+
+    return paginate(fetch_page, page_size=limit, max_pages=max_pages)

--- a/alex/connectors/github_search.py
+++ b/alex/connectors/github_search.py
@@ -1,9 +1,38 @@
 from __future__ import annotations
+from typing import Any
 from alex.utils.http import HttpClient
+from alex.utils.paginate import paginate
 
 GITHUB = "https://api.github.com/search/repositories"
 
-def search(client: HttpClient, query: str, token: str = "", per_page: int = 10) -> list[dict]:
+
+def search(
+    client: HttpClient,
+    query: str,
+    token: str = "",
+    per_page: int = 10,
+    *,
+    from_date: str | None = None,
+    until_date: str | None = None,
+    max_pages: int = 1,
+) -> list[dict[str, Any]]:
+    """Search GitHub repositories.
+
+    Default behaviour (max_pages=1, no date window) preserves the prior
+    single-page fetch. Pass `from_date`/`until_date` (ISO YYYY-MM-DD) to
+    scope results to repos pushed within the window (GitHub search
+    qualifier `pushed:YYYY-MM-DD..YYYY-MM-DD`), and `max_pages > 1` to
+    paginate via `page`.
+    """
+    q = query
+    if from_date and until_date:
+        q = f"{query} pushed:{from_date}..{until_date}"
+
     headers = {"Authorization": f"Bearer {token}"} if token else None
-    data = client.get_json(GITHUB, params={"q": query, "per_page": per_page}, headers=headers)
-    return (data or {}).get("items", [])
+
+    def fetch_page(page_num: int) -> list[dict[str, Any]]:
+        params = {"q": q, "per_page": per_page, "page": page_num}
+        data = client.get_json(GITHUB, params=params, headers=headers) or {}
+        return data.get("items", []) or []
+
+    return paginate(fetch_page, page_size=per_page, max_pages=max_pages)

--- a/alex/connectors/zenodo.py
+++ b/alex/connectors/zenodo.py
@@ -1,8 +1,34 @@
 from __future__ import annotations
+from typing import Any
 from alex.utils.http import HttpClient
+from alex.utils.paginate import paginate
 
 ZENODO = "https://zenodo.org/api/records"
 
-def search(client: HttpClient, query: str, size: int = 25) -> list[dict]:
-    data = client.get_json(ZENODO, params={"q": query, "size": size})
-    return (data or {}).get("hits", {}).get("hits", [])
+
+def search(
+    client: HttpClient,
+    query: str,
+    size: int = 25,
+    *,
+    from_date: str | None = None,
+    until_date: str | None = None,
+    max_pages: int = 1,
+) -> list[dict[str, Any]]:
+    """Search Zenodo records.
+
+    Default behaviour (max_pages=1, no date window) preserves the prior
+    single-page fetch. Pass `from_date`/`until_date` (ISO YYYY-MM-DD) to
+    filter by publication_date via a Lucene range clause in `q`, and
+    `max_pages > 1` to paginate via `page`.
+    """
+    q = query
+    if from_date and until_date:
+        q = f"{query} AND publication_date:[{from_date} TO {until_date}]"
+
+    def fetch_page(page_num: int) -> list[dict[str, Any]]:
+        params = {"q": q, "size": size, "page": page_num}
+        data = client.get_json(ZENODO, params=params) or {}
+        return (data.get("hits") or {}).get("hits", []) or []
+
+    return paginate(fetch_page, page_size=size, max_pages=max_pages)

--- a/alex/pipelines/discovery.py
+++ b/alex/pipelines/discovery.py
@@ -120,7 +120,14 @@ def run() -> None:
                 discovery_query=query,
             )
 
-        for item in core.search(client, query, api_key=os.getenv("CORE_API_KEY", "")):
+        for item in core.search(
+            client,
+            query,
+            api_key=os.getenv("CORE_API_KEY", ""),
+            from_date=from_date,
+            until_date=until_date,
+            max_pages=DISCOVER_MAX_PAGES,
+        ):
             add_row(
                 item.get("title", ""),
                 "CORE",
@@ -133,7 +140,13 @@ def run() -> None:
                 discovery_query=query,
             )
 
-        for item in zenodo.search(client, query):
+        for item in zenodo.search(
+            client,
+            query,
+            from_date=from_date,
+            until_date=until_date,
+            max_pages=DISCOVER_MAX_PAGES,
+        ):
             meta = item.get("metadata") or {}
             creators = "; ".join(c.get("name", "") for c in (meta.get("creators") or []) if c.get("name"))
             add_row(
@@ -147,7 +160,14 @@ def run() -> None:
                 discovery_query=query,
             )
 
-        for item in github_search.search(client, query + " research paper osint cybersecurity", token=os.getenv("GITHUB_TOKEN", "")):
+        for item in github_search.search(
+            client,
+            query + " research paper osint cybersecurity",
+            token=os.getenv("GITHUB_TOKEN", ""),
+            from_date=from_date,
+            until_date=until_date,
+            max_pages=DISCOVER_MAX_PAGES,
+        ):
             add_row(
                 item.get("full_name", ""),
                 "GitHub",

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -1,4 +1,4 @@
-from alex.connectors import openalex, crossref, semantic_scholar
+from alex.connectors import openalex, crossref, semantic_scholar, core, zenodo, github_search
 
 
 class TestOpenAlexAccessors:
@@ -186,3 +186,101 @@ class TestSemanticScholarParsing:
 
     def test_citations_missing(self):
         assert semantic_scholar.citations({}) == []
+
+
+class TestCoreSearch:
+    def test_default_is_single_page_no_filter(self):
+        from unittest.mock import MagicMock
+        client = MagicMock()
+        client.get_json.return_value = {"results": [{"id": 1}]}
+        result = core.search(client, "osint")
+        assert result == [{"id": 1}]
+        assert client.get_json.call_count == 1
+        params = client.get_json.call_args.kwargs["params"]
+        assert params["q"] == "osint"
+        assert params["offset"] == 0
+
+    def test_date_window_appends_to_q(self):
+        from unittest.mock import MagicMock
+        client = MagicMock()
+        client.get_json.return_value = {"results": []}
+        core.search(client, "osint", from_date="2026-04-16", until_date="2026-04-23")
+        params = client.get_json.call_args.kwargs["params"]
+        assert "publishedDate>=2026-04-16" in params["q"]
+        assert "publishedDate<=2026-04-23" in params["q"]
+
+    def test_pagination_increments_offset(self):
+        from unittest.mock import MagicMock
+        client = MagicMock()
+        client.get_json.side_effect = [
+            {"results": [{"id": 1}, {"id": 2}, {"id": 3}]},  # full
+            {"results": [{"id": 4}]},                         # short
+        ]
+        result = core.search(client, "osint", limit=3, max_pages=5)
+        assert len(result) == 4
+        offsets = [c.kwargs["params"]["offset"] for c in client.get_json.call_args_list]
+        assert offsets == [0, 3]
+
+
+class TestZenodoSearch:
+    def test_default_is_single_page_no_filter(self):
+        from unittest.mock import MagicMock
+        client = MagicMock()
+        client.get_json.return_value = {"hits": {"hits": [{"id": 1}]}}
+        result = zenodo.search(client, "osint")
+        assert result == [{"id": 1}]
+        params = client.get_json.call_args.kwargs["params"]
+        assert params["q"] == "osint"
+        assert params["page"] == 1
+
+    def test_date_window_adds_lucene_range(self):
+        from unittest.mock import MagicMock
+        client = MagicMock()
+        client.get_json.return_value = {"hits": {"hits": []}}
+        zenodo.search(client, "osint", from_date="2026-04-16", until_date="2026-04-23")
+        params = client.get_json.call_args.kwargs["params"]
+        assert "publication_date:[2026-04-16 TO 2026-04-23]" in params["q"]
+
+    def test_pagination_increments_page(self):
+        from unittest.mock import MagicMock
+        client = MagicMock()
+        client.get_json.side_effect = [
+            {"hits": {"hits": [{"id": 1}, {"id": 2}, {"id": 3}]}},
+            {"hits": {"hits": [{"id": 4}]}},
+        ]
+        result = zenodo.search(client, "osint", size=3, max_pages=5)
+        assert len(result) == 4
+        pages = [c.kwargs["params"]["page"] for c in client.get_json.call_args_list]
+        assert pages == [1, 2]
+
+
+class TestGithubSearch:
+    def test_default_is_single_page_no_filter(self):
+        from unittest.mock import MagicMock
+        client = MagicMock()
+        client.get_json.return_value = {"items": [{"full_name": "a/b"}]}
+        result = github_search.search(client, "osint")
+        assert result == [{"full_name": "a/b"}]
+        params = client.get_json.call_args.kwargs["params"]
+        assert params["q"] == "osint"
+        assert params["page"] == 1
+
+    def test_date_window_adds_pushed_qualifier(self):
+        from unittest.mock import MagicMock
+        client = MagicMock()
+        client.get_json.return_value = {"items": []}
+        github_search.search(client, "osint", from_date="2026-04-16", until_date="2026-04-23")
+        params = client.get_json.call_args.kwargs["params"]
+        assert "pushed:2026-04-16..2026-04-23" in params["q"]
+
+    def test_pagination_increments_page(self):
+        from unittest.mock import MagicMock
+        client = MagicMock()
+        client.get_json.side_effect = [
+            {"items": [{"id": 1}, {"id": 2}, {"id": 3}]},
+            {"items": [{"id": 4}]},
+        ]
+        result = github_search.search(client, "osint", per_page=3, max_pages=5)
+        assert len(result) == 4
+        pages = [c.kwargs["params"]["page"] for c in client.get_json.call_args_list]
+        assert pages == [1, 2]


### PR DESCRIPTION
Part 3 of #40's sequencing, following PR #41 (OpenAlex + Crossref). Semantic Scholar remains deferred pending #1's rate limiter work.

## What changed

Each connector gains keyword-only `from_date`, `until_date`, `max_pages` args; defaults preserve prior single-page behaviour so nothing else in the repo needs to change.

### `alex/connectors/core.py`
Date filter appended to `q`:
```
<query> AND publishedDate>=X AND publishedDate<=Y
```
Pagination via `offset = (page-1) * limit`.

### `alex/connectors/zenodo.py`
Date filter via Lucene range in `q`:
```
<query> AND publication_date:[X TO Y]
```
Pagination via `page` parameter.

### `alex/connectors/github_search.py`
Date filter via GitHub search qualifier in `q`:
```
<query> pushed:X..Y
```
(scopes to repositories pushed within the window — appropriate for the fact that GitHub search is over repos, not papers). Pagination via `page` + `per_page`.

### `alex/pipelines/discovery.py`
Passes the rolling window + `DISCOVER_MAX_PAGES=10` into all three connectors. arXiv RSS remains as-is (feed is already inherently recent). Semantic Scholar unchanged until #1 lands.

## Live-verified before committing

Real-API smoke test with `2026-04-16..2026-04-23` window:

| Source | Query | Results | Pages | In-window |
|---|---|---|---|---|
| Zenodo | `cybersecurity` | 50 | 2 (full) | 100% |
| GitHub | `osint` | 20 | 2 (full) | 100% |
| CORE | `cybersecurity` | 1 | 1 | 100% |

CORE's low yield is source-inherent (its unfiltered baseline skews to 2016–2020 papers from institutional repositories). The filter is correct; CORE just doesn't have much new content.

## Tests
- 3 new test classes covering each connector: default single-page, date-filter param construction, pagination stop-on-short-page.
- **142 tests pass (was 133).**

## Test plan
- [x] Live smoke-tests against CORE / Zenodo / GitHub (documented above).
- [x] Unit tests verify filter + pagination param construction.
- [ ] After merge: dispatch `pipeline`; verify Discover logs show per-source yields within the 7-day window.

## Remaining in #40
- **Semantic Scholar** pagination + `year` filter — once #1 provides per-host rate limiting + API key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)