### PR TITLE
discover: 7-day window + pagination for Semantic Scholar (closes #40)

### DIFF
--- a/alex/connectors/semantic_scholar.py
+++ b/alex/connectors/semantic_scholar.py
@@ -1,16 +1,88 @@
 from __future__ import annotations
 from typing import Any
 from alex.utils.http import HttpClient
+from alex.utils.paginate import paginate
 
 SEARCH = "https://api.semanticscholar.org/graph/v1/paper/search"
 
-def search(client: HttpClient, query: str, limit: int = 25) -> list[dict[str, Any]]:
-    data = client.get_json(SEARCH, params={
+_SEARCH_FIELDS = (
+    "title,abstract,authors,venue,year,publicationDate,"
+    "citationCount,externalIds,url,references.paperId,citations.paperId"
+)
+
+
+def search(
+    client: HttpClient,
+    query: str,
+    limit: int = 25,
+    *,
+    api_key: str = "",
+    from_date: str | None = None,
+    until_date: str | None = None,
+    max_pages: int = 1,
+) -> list[dict[str, Any]]:
+    """Search Semantic Scholar papers.
+
+    Default behaviour (max_pages=1, no date window, no api_key) preserves
+    the prior single-page fetch for lookup-style callers.
+
+    Pass `from_date`/`until_date` (ISO YYYY-MM-DD) for a date window — sent
+    as `publicationDateOrYear=X:Y` per Semantic Scholar's documented range
+    format. A client-side post-filter on `publicationDate` is applied as a
+    safety net (in case the server's range filtering is partial).
+
+    Pass `api_key` to send the `x-api-key` header — required for practical
+    pagination without tripping the free-tier 100-req/5min limit.
+
+    `max_pages` is deliberately low by default (caller should cap at 2-3
+    even with a key; without a key, more than 1 is risky).
+    """
+    headers = {"x-api-key": api_key} if api_key else None
+
+    base_params: dict[str, Any] = {
         "query": query,
         "limit": limit,
-        "fields": "title,abstract,authors,venue,year,citationCount,externalIds,url,references.paperId,citations.paperId"
-    })
-    return (data or {}).get("data", [])
+        "fields": _SEARCH_FIELDS,
+    }
+    if from_date and until_date:
+        base_params["publicationDateOrYear"] = f"{from_date}:{until_date}"
+
+    def fetch_page(page_num: int) -> list[dict[str, Any]]:
+        params = dict(base_params)
+        params["offset"] = (page_num - 1) * limit
+        data = client.get_json(SEARCH, params=params, headers=headers) or {}
+        return data.get("data", []) or []
+
+    results = paginate(fetch_page, page_size=limit, max_pages=max_pages)
+
+    # Client-side safety filter: drop anything outside the window. Protects
+    # against API variants that only partially honour publicationDateOrYear.
+    if from_date and until_date:
+        results = [
+            r for r in results
+            if _in_window(r.get("publicationDate") or "", from_date, until_date)
+            or _year_in_window(r.get("year"), from_date, until_date)
+        ]
+
+    return results
+
+
+def _in_window(pub_date: str, from_date: str, until_date: str) -> bool:
+    if not pub_date:
+        return False
+    return from_date <= pub_date[:10] <= until_date
+
+
+def _year_in_window(year: Any, from_date: str, until_date: str) -> bool:
+    # Fallback when publicationDate isn't present but year is. Keep the
+    # record if its year overlaps the window's year range.
+    if year is None:
+        return False
+    try:
+        y = int(year)
+    except (TypeError, ValueError):
+        return False
+    return int(from_date[:4]) <= y <= int(until_date[:4])
 
 PAPER = "https://api.semanticscholar.org/graph/v1/paper"
 

--- a/alex/pipelines/discovery.py
+++ b/alex/pipelines/discovery.py
@@ -106,7 +106,18 @@ def run() -> None:
                 discovery_query=query,
             )
 
-        for item in semantic_scholar.search(client, query):
+        for item in semantic_scholar.search(
+            client,
+            query,
+            api_key=os.getenv("SEMANTIC_SCHOLAR_API_KEY", ""),
+            from_date=from_date,
+            until_date=until_date,
+            # Cap Semantic Scholar pagination tighter than the other sources:
+            # even with an API key the free-plus tier is 100 req/5min. Without
+            # a key the API will 429 quickly, and we'll fall back to whatever
+            # page 1 returned.
+            max_pages=2,
+        ):
             add_row(
                 item.get("title", ""),
                 "Semantic Scholar",

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -188,6 +188,70 @@ class TestSemanticScholarParsing:
         assert semantic_scholar.citations({}) == []
 
 
+class TestSemanticScholarSearch:
+    def test_default_is_single_page_no_filter_no_auth(self):
+        from unittest.mock import MagicMock
+        client = MagicMock()
+        client.get_json.return_value = {"data": [{"title": "A"}]}
+        result = semantic_scholar.search(client, "osint")
+        assert result == [{"title": "A"}]
+        assert client.get_json.call_count == 1
+        kwargs = client.get_json.call_args.kwargs
+        assert kwargs["params"]["query"] == "osint"
+        assert kwargs["params"]["offset"] == 0
+        assert "publicationDateOrYear" not in kwargs["params"]
+        assert kwargs.get("headers") is None  # no api_key -> no header
+
+    def test_api_key_sets_header(self):
+        from unittest.mock import MagicMock
+        client = MagicMock()
+        client.get_json.return_value = {"data": []}
+        semantic_scholar.search(client, "osint", api_key="abc123")
+        kwargs = client.get_json.call_args.kwargs
+        assert kwargs["headers"] == {"x-api-key": "abc123"}
+
+    def test_date_window_sets_param(self):
+        from unittest.mock import MagicMock
+        client = MagicMock()
+        client.get_json.return_value = {"data": []}
+        semantic_scholar.search(client, "osint", from_date="2026-04-16", until_date="2026-04-23")
+        params = client.get_json.call_args.kwargs["params"]
+        assert params["publicationDateOrYear"] == "2026-04-16:2026-04-23"
+
+    def test_client_side_filter_drops_out_of_window_results(self):
+        from unittest.mock import MagicMock
+        client = MagicMock()
+        # Simulate an API that ignores the filter and returns mixed dates
+        client.get_json.return_value = {"data": [
+            {"title": "in window", "publicationDate": "2026-04-18"},
+            {"title": "too old",   "publicationDate": "2020-01-01"},
+            {"title": "too new",   "publicationDate": "2030-01-01"},
+            {"title": "no date but in-year", "year": 2026},
+            {"title": "no date wrong year", "year": 1999},
+        ]}
+        result = semantic_scholar.search(
+            client, "osint", from_date="2026-04-16", until_date="2026-04-23",
+        )
+        titles = {r["title"] for r in result}
+        assert "in window" in titles
+        assert "no date but in-year" in titles  # year fallback keeps it
+        assert "too old" not in titles
+        assert "too new" not in titles
+        assert "no date wrong year" not in titles
+
+    def test_pagination_increments_offset(self):
+        from unittest.mock import MagicMock
+        client = MagicMock()
+        client.get_json.side_effect = [
+            {"data": [{"title": f"p{i}"} for i in range(3)]},  # full
+            {"data": [{"title": "last"}]},                     # short
+        ]
+        result = semantic_scholar.search(client, "osint", limit=3, max_pages=5)
+        assert len(result) == 4
+        offsets = [c.kwargs["params"]["offset"] for c in client.get_json.call_args_list]
+        assert offsets == [0, 3]
+
+
 class TestCoreSearch:
     def test_default_is_single_page_no_filter(self):
         from unittest.mock import MagicMock


### PR DESCRIPTION
Part 2 of #40, closing the last source. Together with PR #41 (OpenAlex + Crossref) and PR #42 (CORE + Zenodo + GitHub), this should close issue #40.

Also partially addresses #1 — this PR wires the `x-api-key` header. The remaining pieces of #1 (per-host rate limiter in HttpClient, exponential backoff on 429) stay in #1's scope.

## Changes

### `alex/connectors/semantic_scholar.py`

- Keyword-only `from_date`, `until_date`, `api_key`, `max_pages`.
- Defaults preserve prior single-page behaviour for lookup-style callers (harvest and citation_chain both call `semantic_scholar.search` ad-hoc).
- Date window sent as `publicationDateOrYear=X:Y` per SS's documented range format.
- **Client-side safety filter** drops results outside the window, with a year-level fallback when `publicationDate` is absent. Defensive in case the server's range filter is partial.
- `api_key` sends the `x-api-key` header. Without a key the free-tier 100-req/5min cap is easy to hit (confirmed by live smoke-test — got 429 immediately).

### `alex/pipelines/discovery.py`

Passes the 7-day window, `SEMANTIC_SCHOLAR_API_KEY` env var, and **`max_pages=2`** (tighter than the 10 used for other sources) into SS search. Even with a key we want to burn less rate-limit budget here.

### Tests
Five new SS cases in `tests/test_connectors.py`:
- Default single-page, no filter, no auth header
- `api_key` sets `x-api-key` header
- Date window sets `publicationDateOrYear` param
- Client-side filter drops out-of-window results (including year-fallback logic)
- Pagination increments `offset`

**147 tests pass** (was 142).

## Live smoke test (cannot complete without API key)

Verified request construction by examining the 429 error URL:
```
.../paper/search?query=OSINT+methodology
                &limit=10
                &fields=title,abstract,authors,venue,year,publicationDate,...
                &publicationDateOrYear=2026-04-16:2026-04-23
                &offset=0
```

Params are URL-encoded correctly. Connector handled the 429 gracefully (HttpClient returned None, connector returned empty list, no crash). Once `SEMANTIC_SCHOLAR_API_KEY` is provisioned and `x-api-key` starts being accepted, the full path will execute.

## What this does NOT solve
- Without `SEMANTIC_SCHOLAR_API_KEY`, the pipeline still 429s on SS. **Issue #1** tracks the remaining pieces (per-host rate limiter, 429 backoff). Once a key is available, raise `max_pages` for SS.
- arXiv RSS unchanged — still the only inherently-windowed source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)