### PR TITLE
[codex] Add post-harvest rescore stage

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -59,6 +59,12 @@ jobs:
           git add data/accepted_harvested.csv
           git diff --cached --quiet || git commit -m "Harvest metadata"
           git push
+      - name: Rescore
+        run: |
+          python -m alex.cli rescore
+          git add data/accepted_harvested.csv data/rescore_metrics.csv
+          git diff --cached --quiet || git commit -m "Post-harvest rescore"
+          git push
       - name: Classify
         env:
           OPENAI_API_KEY: ${{ secrets.OPEN_API_KEY }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -61,9 +61,10 @@ jobs:
           git push
       - name: Rescore
         run: |
-          python -m alex.cli rescore
+          SUMMARY=$(python -m alex.cli rescore | tail -n1)
+          echo "$SUMMARY"
           git add data/accepted_harvested.csv data/rescore_metrics.csv
-          git diff --cached --quiet || git commit -m "Post-harvest rescore"
+          git diff --cached --quiet || git commit -m "Post-harvest rescore: ${SUMMARY:-no summary}"
           git push
       - name: Classify
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 # Alex cache
 .alex_cache.json
 .harvest_cache.json
+data/.rescore_window.json
 
 # Planning and execution artifacts (local only)
 docs/superpowers/

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ flowchart TB
         citation["Citation chain"]:::step
         quality["Quality gate"]:::step
         harvest["Harvest"]:::step
+        rescorestep["Rescore"]:::step
         classify["Classify (LLM)"]:::step
         publish["Publish assets"]:::step
     end
@@ -198,7 +199,7 @@ flowchart TB
     site[("data/papers.json<br/>data/osint_cyber_papers.csv")]:::data
 
     cronMon --> discover
-    discover --> citation --> quality --> harvest --> classify --> publish
+    discover --> citation --> quality --> harvest --> rescorestep --> classify --> publish
     publish -- needs --> pages
 
     discover -.writes.-> dc
@@ -207,6 +208,8 @@ flowchart TB
     quality -.writes.-> ac
     ac -.reads.-> harvest
     harvest -.writes.-> ah
+    ah -.reads.-> rescorestep
+    rescorestep -.filters.-> ah
     ah -.reads.-> classify
     classify -.writes.-> acl
     acl -.reads.-> publish

--- a/alex/cli.py
+++ b/alex/cli.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import argparse
 import logging
-from alex.pipelines import discovery, citation_chain, quality_gate, harvest, classify, publish
+from alex.pipelines import discovery, citation_chain, quality_gate, harvest, rescore, classify, publish
 
 
 def main():
@@ -11,13 +11,14 @@ def main():
         datefmt="%Y-%m-%d %H:%M:%S",
     )
     ap = argparse.ArgumentParser(prog="alex", description="OSINT research corpus pipeline")
-    ap.add_argument("command", choices=["discover", "chain", "score", "harvest", "classify", "publish"])
+    ap.add_argument("command", choices=["discover", "chain", "score", "harvest", "rescore", "classify", "publish"])
     args = ap.parse_args()
     {
         "discover": discovery.run,
         "chain": citation_chain.run,
         "score": quality_gate.run,
         "harvest": harvest.run,
+        "rescore": rescore.run,
         "classify": classify.run,
         "publish": publish.run,
     }[args.command]()

--- a/alex/pipelines/__init__.py
+++ b/alex/pipelines/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ["discovery", "citation_chain", "quality_gate", "harvest", "classify", "publish"]
+__all__ = ["discovery", "citation_chain", "quality_gate", "harvest", "rescore", "classify", "publish"]

--- a/alex/pipelines/classify.py
+++ b/alex/pipelines/classify.py
@@ -84,7 +84,8 @@ def _dedup_key(row) -> str:
 def run() -> None:
     output_path = root_file("data", "accepted_classified.csv")
     df = load_df(root_file("data", "accepted_harvested.csv"))
-    if df.empty:
+    rescored = load_df(root_file("data", "rescore_metrics.csv"))
+    if df.empty and rescored.empty:
         print("No harvested accepted candidates to classify.")
         # Additive model: don't overwrite the existing published corpus on
         # empty input. Only create an empty placeholder if no corpus exists
@@ -92,40 +93,50 @@ def run() -> None:
         if not output_path.exists():
             save_df(output_path, pd.DataFrame())
         return
-    validate_columns(df, ["title", "abstract", "venue", "authors", "citation_count"], "accepted_harvested.csv")
+
+    if not df.empty:
+        validate_columns(df, ["title", "abstract", "venue", "authors", "citation_count"], "accepted_harvested.csv")
+
     rows = []
-    for _, row in df.iterrows():
-        payload = {
-            "title": clean(row.get("title")),
-            "abstract": clean(row.get("abstract")),
-            "venue": clean(row.get("venue")),
-            "authors": clean(row.get("authors")),
-        }
-        tags = call_openai(payload)
-        out = dict(row)
-        out["Category"] = tags.get("Category", "Other")
-        out["Investigation_Type"] = tags.get("Investigation_Type", "Other")
-        out["OSINT_Source_Types"] = "; ".join(unique_keep(tags.get("OSINT_Source_Types", [])))
-        out["Keywords"] = "; ".join(unique_keep(tags.get("Keywords", [])))
-        out["Tags"] = "; ".join(unique_keep(tags.get("Tags", [])))
-        out["Quality_Tier"] = tags.get("Quality_Tier", "Standard")
-        out["Seminal_Flag"] = "TRUE" if _safe_citation_count(row) >= 500 else "FALSE"
-        rows.append(out)
+    if not df.empty:
+        for _, row in df.iterrows():
+            payload = {
+                "title": clean(row.get("title")),
+                "abstract": clean(row.get("abstract")),
+                "venue": clean(row.get("venue")),
+                "authors": clean(row.get("authors")),
+            }
+            tags = call_openai(payload)
+            out = dict(row)
+            out["Category"] = tags.get("Category", "Other")
+            out["Investigation_Type"] = tags.get("Investigation_Type", "Other")
+            out["OSINT_Source_Types"] = "; ".join(unique_keep(tags.get("OSINT_Source_Types", [])))
+            out["Keywords"] = "; ".join(unique_keep(tags.get("Keywords", [])))
+            out["Tags"] = "; ".join(unique_keep(tags.get("Tags", [])))
+            out["Quality_Tier"] = tags.get("Quality_Tier", "Standard")
+            out["Seminal_Flag"] = "TRUE" if _safe_citation_count(row) >= 500 else "FALSE"
+            rows.append(out)
 
     new_df = pd.DataFrame(rows)
 
     # Additive merge: preserve every paper ever classified. Fresh classifier
-    # output wins on conflict (newer metadata, latest tags). Dedup by DOI
-    # where available, falling back to normalised title. Earlier seed rows
-    # without scoring columns coexist with pipeline-generated rows via
-    # column union (missing fields fill as NaN, which publish.fillna('')
-    # collapses to empty strings).
+    # output wins on conflict (newer metadata, latest tags). When rescore
+    # metrics are available, treat that current window as authoritative:
+    # rows reconsidered this run are removed from the existing corpus, then
+    # only the surviving accepted rows are added back.
     existing = load_df(output_path)
+    rescored_keys = set()
+    if not rescored.empty:
+        rescored_keys = {_dedup_key(row) for _, row in rescored.iterrows()}
+    new_keys = {_dedup_key(row) for _, row in new_df.iterrows()}
+    replacement_keys = rescored_keys or new_keys
+
     if existing.empty:
         merged: pd.DataFrame = new_df
+    elif not replacement_keys:
+        merged = existing
     else:
-        new_keys = list({_dedup_key(row) for _, row in new_df.iterrows()})
-        existing_keep = existing[~existing.apply(_dedup_key, axis=1).isin(new_keys)]
+        existing_keep = existing[~existing.apply(_dedup_key, axis=1).isin(replacement_keys)]
         merged = pd.concat([existing_keep, new_df], ignore_index=True)
 
     save_df(output_path, merged)

--- a/alex/pipelines/classify.py
+++ b/alex/pipelines/classify.py
@@ -81,10 +81,37 @@ def _dedup_key(row) -> str:
     return f"title:{normalize_title(clean(row.get('title', '')))}"
 
 
+def _load_rescore_window_run_id() -> str:
+    path = root_file("data", ".rescore_window.json")
+    if not path.exists():
+        return ""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        logger.warning("Ignoring malformed rescore window token: %s", path)
+        return ""
+    return clean(data.get("run_id", ""))
+
+
+def _rows_match_run_id(df: pd.DataFrame, run_id: str, context: str) -> bool:
+    if df.empty:
+        return True
+    if "rescore_run_id" not in df.columns:
+        logger.warning("Ignoring rescore pruning: %s missing rescore_run_id", context)
+        return False
+    values = {clean(v) for v in df["rescore_run_id"].tolist() if clean(v)}
+    if values != {run_id}:
+        logger.warning("Ignoring rescore pruning: %s run_id mismatch (%s)", context, sorted(values))
+        return False
+    return True
+
+
 def run() -> None:
     output_path = root_file("data", "accepted_classified.csv")
+    window_path = root_file("data", ".rescore_window.json")
     df = load_df(root_file("data", "accepted_harvested.csv"))
     rescored = load_df(root_file("data", "rescore_metrics.csv"))
+    window_run_id = _load_rescore_window_run_id()
     if df.empty and rescored.empty:
         print("No harvested accepted candidates to classify.")
         # Additive model: don't overwrite the existing published corpus on
@@ -92,6 +119,8 @@ def run() -> None:
         # yet (so downstream workflows can still `git add` cleanly).
         if not output_path.exists():
             save_df(output_path, pd.DataFrame())
+        if window_path.exists():
+            window_path.unlink()
         return
 
     if not df.empty:
@@ -126,7 +155,8 @@ def run() -> None:
     # only the surviving accepted rows are added back.
     existing = load_df(output_path)
     rescored_keys = set()
-    if not rescored.empty:
+    if window_run_id and _rows_match_run_id(rescored, window_run_id, "rescore_metrics.csv") \
+       and _rows_match_run_id(df, window_run_id, "accepted_harvested.csv"):
         rescored_keys = {_dedup_key(row) for _, row in rescored.iterrows()}
     new_keys = {_dedup_key(row) for _, row in new_df.iterrows()}
     replacement_keys = rescored_keys or new_keys
@@ -140,4 +170,6 @@ def run() -> None:
         merged = pd.concat([existing_keep, new_df], ignore_index=True)
 
     save_df(output_path, merged)
+    if window_path.exists():
+        window_path.unlink()
     print(f"Classified {len(rows)} new papers; corpus now {len(merged)} (was {len(existing)})")

--- a/alex/pipelines/quality_gate.py
+++ b/alex/pipelines/quality_gate.py
@@ -10,6 +10,11 @@ from alex.utils.text import clean
 
 logger = logging.getLogger(__name__)
 
+# Discovery sources that produce preprints — these get a separate scoring
+# ladder because they structurally lack venue/citation/institution signal
+# (new papers, not yet indexed in whitelisted venues, zero citations).
+_PREPRINT_SOURCES = {"arXiv RSS"}
+
 
 def _safe_float(val, default: float = 0.0) -> float:
     try:
@@ -23,6 +28,10 @@ def _safe_int_year(val) -> int | None:
     if s.isdigit():
         return int(s)
     return None
+
+
+def _is_preprint(row) -> bool:
+    return clean(row.get("discovery_source", "")) in _PREPRINT_SOURCES
 
 
 def run() -> None:
@@ -41,6 +50,14 @@ def run() -> None:
     accepted, review, rejected = [], [], []
 
     institution_bonus = float(weights.get("institution_bonus", 0.0))
+
+    # Regular (peer-reviewed) thresholds
+    auto_include = float(weights["auto_include_threshold"])
+    review_cutoff = float(weights["review_threshold"])
+    # Preprint-specific thresholds (arXiv etc). Fall back to regular thresholds
+    # if not configured so the change is backwards-compatible.
+    preprint_auto = float(weights.get("preprint_auto_include_threshold", auto_include))
+    preprint_review = float(weights.get("preprint_review_threshold", review_cutoff))
 
     for i, (_, row) in enumerate(df.iterrows()):
         v = venue_score(row.get("venue", ""), whitelist)
@@ -61,9 +78,18 @@ def run() -> None:
         # on a signal we can't reliably measure.
         bonus = institution_bonus if i_score >= 0.7 else 0.0
         total = min(100.0, base + bonus)
+        preprint = _is_preprint(row)
+        # Preprints ride on a separate ladder — they can't reach regular
+        # thresholds because they lack venue/citation/institution signal by
+        # nature (new papers, not yet indexed in whitelisted venues, zero
+        # citations). Relevance-heavy preprints still deserve a slot.
+        t_auto = preprint_auto if preprint else auto_include
+        t_review = preprint_review if preprint else review_cutoff
+
         out = dict(row)
         out["candidate_id"] = i + 1
         out["scored_at"] = now
+        out["is_preprint"] = preprint
         out["venue_score"] = round(v * 100, 2)
         out["citation_score"] = round(c * 100, 2)
         out["institution_score"] = round(i_score * 100, 2)
@@ -71,11 +97,11 @@ def run() -> None:
         out["relevance_score"] = round(r * 100, 2)
         out["total_quality_score"] = round(total, 2)
 
-        if total >= weights["auto_include_threshold"]:
+        if total >= t_auto:
             out["review_reason"] = ""
             out["recommended_action"] = "auto-include"
             accepted.append(out)
-        elif total >= weights["review_threshold"]:
+        elif total >= t_review:
             out["review_reason"] = "Quality uncertain or moderate"
             out["recommended_action"] = "human review"
             review.append(out)
@@ -88,6 +114,14 @@ def run() -> None:
     save_df(root_file("data", "quality_metrics.csv"), pd.DataFrame(metrics))
     save_df(root_file("data", "review_queue.csv"), pd.DataFrame(review))
     save_df(root_file("data", "rejected_candidates.csv"), pd.DataFrame(rejected))
-    save_df(root_file("data", "accepted_candidates.csv"), pd.DataFrame(accepted))
-    logger.info("Quality gate: Accepted=%d Review=%d Rejected=%d", len(accepted), len(review), len(rejected))
-    print(f"Accepted={len(accepted)} Review={len(review)} Rejected={len(rejected)}")
+    # accepted_candidates.csv contains BOTH auto-include and human-review tiers
+    # so harvest enriches everything worth a second look. The post-harvest
+    # rescore stage (alex.pipelines.rescore) filters back down to auto-include
+    # once abstracts are fully populated. review_queue.csv still lists the
+    # human-review tier as a separate informational output.
+    enrichment_pool = accepted + review
+    save_df(root_file("data", "accepted_candidates.csv"), pd.DataFrame(enrichment_pool))
+    logger.info("Quality gate: Accepted=%d Review=%d Rejected=%d (for harvest: %d)",
+                len(accepted), len(review), len(rejected), len(enrichment_pool))
+    print(f"Accepted={len(accepted)} Review={len(review)} Rejected={len(rejected)} "
+          f"(enrichment pool: {len(enrichment_pool)})")

--- a/alex/pipelines/quality_gate.py
+++ b/alex/pipelines/quality_gate.py
@@ -5,33 +5,17 @@ from datetime import datetime, timezone
 import pandas as pd
 
 from alex.utils.io import load_df, save_df, load_json, root_file, validate_columns
-from alex.utils.scoring import venue_score, citation_score, institution_score, relevance_score
-from alex.utils.text import clean
+from alex.utils.scoring import (
+    venue_score,
+    citation_score,
+    institution_score,
+    relevance_score,
+    safe_float,
+    safe_int_year,
+    is_preprint,
+)
 
 logger = logging.getLogger(__name__)
-
-# Discovery sources that produce preprints — these get a separate scoring
-# ladder because they structurally lack venue/citation/institution signal
-# (new papers, not yet indexed in whitelisted venues, zero citations).
-_PREPRINT_SOURCES = {"arXiv RSS"}
-
-
-def _safe_float(val, default: float = 0.0) -> float:
-    try:
-        return float(val) if val is not None and val != "" else default
-    except (ValueError, TypeError):
-        return default
-
-
-def _safe_int_year(val) -> int | None:
-    s = clean(val)
-    if s.isdigit():
-        return int(s)
-    return None
-
-
-def _is_preprint(row) -> bool:
-    return clean(row.get("discovery_source", "")) in _PREPRINT_SOURCES
 
 
 def run() -> None:
@@ -56,12 +40,16 @@ def run() -> None:
     review_cutoff = float(weights["review_threshold"])
     # Preprint-specific thresholds (arXiv etc). Fall back to regular thresholds
     # if not configured so the change is backwards-compatible.
+    # Monitor the preprint-tier promotion rate in rescore output (`preprints: X/Y`);
+    # tune `preprint_auto_include_threshold` up if the preprint tier floods the
+    # corpus — the default 35 is permissive given preprints score mostly on
+    # relevance + institution bonus.
     preprint_auto = float(weights.get("preprint_auto_include_threshold", auto_include))
     preprint_review = float(weights.get("preprint_review_threshold", review_cutoff))
 
     for i, (_, row) in enumerate(df.iterrows()):
         v = venue_score(row.get("venue", ""), whitelist)
-        c = citation_score(_safe_float(row.get("citation_count")), _safe_int_year(row.get("year")))
+        c = citation_score(safe_float(row.get("citation_count")), safe_int_year(row.get("year")))
         # Read the dedicated affiliations field (populated by OpenAlex connector).
         # Falls back to authors for rows ingested before the field existed, though
         # those typically hold names only and won't hit the trusted keywords.
@@ -78,7 +66,7 @@ def run() -> None:
         # on a signal we can't reliably measure.
         bonus = institution_bonus if i_score >= 0.7 else 0.0
         total = min(100.0, base + bonus)
-        preprint = _is_preprint(row)
+        preprint = is_preprint(row)
         # Preprints ride on a separate ladder — they can't reach regular
         # thresholds because they lack venue/citation/institution signal by
         # nature (new papers, not yet indexed in whitelisted venues, zero

--- a/alex/pipelines/rescore.py
+++ b/alex/pipelines/rescore.py
@@ -25,12 +25,28 @@ from alex.pipelines.quality_gate import _is_preprint, _safe_float, _safe_int_yea
 
 logger = logging.getLogger(__name__)
 
+_EMPTY_RESCORE_COLUMNS = [
+    "title",
+    "doi",
+    "is_preprint",
+    "venue_score",
+    "citation_score",
+    "institution_score",
+    "institution_bonus",
+    "relevance_score",
+    "total_quality_score",
+]
+
 
 def run() -> None:
     harvested_path = root_file("data", "accepted_harvested.csv")
+    metrics_path = root_file("data", "rescore_metrics.csv")
     df = load_df(harvested_path)
     if df.empty:
         print("No harvested candidates to rescore.")
+        # Always emit the metrics placeholder so workflow `git add` steps do
+        # not fail on empty weeks.
+        save_df(metrics_path, pd.DataFrame(columns=_EMPTY_RESCORE_COLUMNS))
         # Don't overwrite with an empty file if the file already exists —
         # same safety pattern as classify.py's additive corpus logic.
         if not harvested_path.exists():
@@ -81,7 +97,7 @@ def run() -> None:
     accepted_df: pd.DataFrame = rescored[rescored.apply(_passes, axis=1)]
 
     # Full rescored corpus to a metrics file for debugging / audit
-    save_df(root_file("data", "rescore_metrics.csv"), rescored)
+    save_df(metrics_path, rescored)
     # Filtered auto-include tier back into accepted_harvested.csv — this is
     # what classify reads next.
     save_df(harvested_path, accepted_df)

--- a/alex/pipelines/rescore.py
+++ b/alex/pipelines/rescore.py
@@ -13,21 +13,29 @@ Output: data/accepted_harvested.csv   (filtered to auto-include tier)
 """
 
 from __future__ import annotations
+import json
 import logging
+from uuid import uuid4
 
 import pandas as pd
 
 from alex.utils.io import load_df, save_df, load_json, root_file
-from alex.utils.scoring import venue_score, citation_score, institution_score, relevance_score
-# Reuse preprint detection from the initial gate so classification is
-# consistent across both stages.
-from alex.pipelines.quality_gate import _is_preprint, _safe_float, _safe_int_year
+from alex.utils.scoring import (
+    venue_score,
+    citation_score,
+    institution_score,
+    relevance_score,
+    safe_float,
+    safe_int_year,
+    is_preprint,
+)
 
 logger = logging.getLogger(__name__)
 
 _EMPTY_RESCORE_COLUMNS = [
     "title",
     "doi",
+    "rescore_run_id",
     "is_preprint",
     "venue_score",
     "citation_score",
@@ -41,12 +49,15 @@ _EMPTY_RESCORE_COLUMNS = [
 def run() -> None:
     harvested_path = root_file("data", "accepted_harvested.csv")
     metrics_path = root_file("data", "rescore_metrics.csv")
+    window_path = root_file("data", ".rescore_window.json")
     df = load_df(harvested_path)
     if df.empty:
         print("No harvested candidates to rescore.")
         # Always emit the metrics placeholder so workflow `git add` steps do
         # not fail on empty weeks.
         save_df(metrics_path, pd.DataFrame(columns=_EMPTY_RESCORE_COLUMNS))
+        if window_path.exists():
+            window_path.unlink()
         # Don't overwrite with an empty file if the file already exists —
         # same safety pattern as classify.py's additive corpus logic.
         if not harvested_path.exists():
@@ -60,11 +71,12 @@ def run() -> None:
     institution_bonus = float(weights.get("institution_bonus", 0.0))
     auto_include = float(weights["auto_include_threshold"])
     preprint_auto = float(weights.get("preprint_auto_include_threshold", auto_include))
+    run_id = uuid4().hex
 
     rescored_rows = []
     for _, row in df.iterrows():
         v = venue_score(row.get("venue", ""), whitelist)
-        c = citation_score(_safe_float(row.get("citation_count")), _safe_int_year(row.get("year")))
+        c = citation_score(safe_float(row.get("citation_count")), safe_int_year(row.get("year")))
         affiliations_text = row.get("affiliations", "") or row.get("authors", "")
         i_score = institution_score(affiliations_text)
         r = relevance_score(row.get("title", ""), row.get("abstract", ""), queries)
@@ -75,9 +87,10 @@ def run() -> None:
         )
         bonus = institution_bonus if i_score >= 0.7 else 0.0
         total = min(100.0, base + bonus)
-        preprint = _is_preprint(row)
+        preprint = is_preprint(row)
 
         out = dict(row)
+        out["rescore_run_id"] = run_id
         out["is_preprint"] = preprint
         out["venue_score"] = round(v * 100, 2)
         out["citation_score"] = round(c * 100, 2)
@@ -101,6 +114,7 @@ def run() -> None:
     # Filtered auto-include tier back into accepted_harvested.csv — this is
     # what classify reads next.
     save_df(harvested_path, accepted_df)
+    window_path.write_text(json.dumps({"run_id": run_id}), encoding="utf-8")
 
     promoted = len(accepted_df)
     total_rescored = len(rescored)

--- a/alex/pipelines/rescore.py
+++ b/alex/pipelines/rescore.py
@@ -1,0 +1,100 @@
+"""Post-harvest rescore step.
+
+Papers enter quality_gate with whatever abstract the initial discovery
+connector shipped. Harvest then re-fetches authoritative metadata and fills
+in gaps (Crossref abstracts, OpenAlex abstract_inverted_index, Semantic
+Scholar). This stage re-runs relevance_score against the now-enriched text
+and applies the final auto-include gate — with separate preprint routing
+so arXiv/bioRxiv/medRxiv/SSRN papers get a realistic threshold.
+
+Input:  data/accepted_harvested.csv   (harvest's output — enrichment pool)
+Output: data/accepted_harvested.csv   (filtered to auto-include tier)
+        data/rescore_metrics.csv      (full rescored set, for debugging)
+"""
+
+from __future__ import annotations
+import logging
+
+import pandas as pd
+
+from alex.utils.io import load_df, save_df, load_json, root_file
+from alex.utils.scoring import venue_score, citation_score, institution_score, relevance_score
+# Reuse preprint detection from the initial gate so classification is
+# consistent across both stages.
+from alex.pipelines.quality_gate import _is_preprint, _safe_float, _safe_int_year
+
+logger = logging.getLogger(__name__)
+
+
+def run() -> None:
+    harvested_path = root_file("data", "accepted_harvested.csv")
+    df = load_df(harvested_path)
+    if df.empty:
+        print("No harvested candidates to rescore.")
+        # Don't overwrite with an empty file if the file already exists —
+        # same safety pattern as classify.py's additive corpus logic.
+        if not harvested_path.exists():
+            save_df(harvested_path, pd.DataFrame())
+        return
+
+    whitelist = load_json(root_file("config", "venue_whitelist.json"))["high_trust"]
+    queries = load_json(root_file("config", "query_registry.json"))["queries"]
+    weights = load_json(root_file("config", "quality_weights.json"))
+
+    institution_bonus = float(weights.get("institution_bonus", 0.0))
+    auto_include = float(weights["auto_include_threshold"])
+    preprint_auto = float(weights.get("preprint_auto_include_threshold", auto_include))
+
+    rescored_rows = []
+    for _, row in df.iterrows():
+        v = venue_score(row.get("venue", ""), whitelist)
+        c = citation_score(_safe_float(row.get("citation_count")), _safe_int_year(row.get("year")))
+        affiliations_text = row.get("affiliations", "") or row.get("authors", "")
+        i_score = institution_score(affiliations_text)
+        r = relevance_score(row.get("title", ""), row.get("abstract", ""), queries)
+        base = 100 * (
+            v * weights["venue"]
+            + c * weights["citations"]
+            + r * weights["relevance"]
+        )
+        bonus = institution_bonus if i_score >= 0.7 else 0.0
+        total = min(100.0, base + bonus)
+        preprint = _is_preprint(row)
+
+        out = dict(row)
+        out["is_preprint"] = preprint
+        out["venue_score"] = round(v * 100, 2)
+        out["citation_score"] = round(c * 100, 2)
+        out["institution_score"] = round(i_score * 100, 2)
+        out["institution_bonus"] = round(bonus, 2)
+        out["relevance_score"] = round(r * 100, 2)
+        out["total_quality_score"] = round(total, 2)
+        rescored_rows.append(out)
+
+    rescored = pd.DataFrame(rescored_rows)
+
+    # Per-row auto-include threshold. Preprints on their own ladder.
+    def _passes(row) -> bool:
+        threshold = preprint_auto if row["is_preprint"] else auto_include
+        return row["total_quality_score"] >= threshold
+
+    accepted_df: pd.DataFrame = rescored[rescored.apply(_passes, axis=1)]
+
+    # Full rescored corpus to a metrics file for debugging / audit
+    save_df(root_file("data", "rescore_metrics.csv"), rescored)
+    # Filtered auto-include tier back into accepted_harvested.csv — this is
+    # what classify reads next.
+    save_df(harvested_path, accepted_df)
+
+    promoted = len(accepted_df)
+    total_rescored = len(rescored)
+    preprints_in = int(rescored["is_preprint"].sum()) if len(rescored) else 0
+    preprints_out = int(accepted_df["is_preprint"].sum()) if len(accepted_df) else 0
+    logger.info(
+        "Rescore: %d rows -> %d auto-include (preprints: %d/%d)",
+        total_rescored, promoted, preprints_out, preprints_in,
+    )
+    print(
+        f"Rescored {total_rescored}; {promoted} meet auto-include "
+        f"(preprints: {preprints_out}/{preprints_in})"
+    )

--- a/alex/utils/scoring.py
+++ b/alex/utils/scoring.py
@@ -3,6 +3,29 @@ from math import log1p, isnan
 from typing import Any
 from .text import clean
 
+# Discovery sources that produce preprints — these route on a separate
+# scoring ladder because they structurally lack venue/citation/institution
+# signal (new papers, not yet indexed in whitelisted venues, zero citations).
+PREPRINT_SOURCES = {"arXiv RSS"}
+
+
+def safe_float(val: Any, default: float = 0.0) -> float:
+    try:
+        return float(val) if val is not None and val != "" else default
+    except (ValueError, TypeError):
+        return default
+
+
+def safe_int_year(val: Any) -> int | None:
+    s = clean(val)
+    if s.isdigit():
+        return int(s)
+    return None
+
+
+def is_preprint(row: Any) -> bool:
+    return clean(row.get("discovery_source", "")) in PREPRINT_SOURCES
+
 
 def venue_score(venue: Any, whitelist: list[str]) -> float:
     v = clean(venue)

--- a/config/quality_weights.json
+++ b/config/quality_weights.json
@@ -5,5 +5,7 @@
   "institution_bonus": 10.0,
   "auto_include_threshold": 75.0,
   "review_threshold": 45.0,
+  "preprint_auto_include_threshold": 35.0,
+  "preprint_review_threshold": 20.0,
   "seminal_citation_threshold": 500
 }

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -376,6 +376,7 @@ class TestClassify:
         # rescore window but does not survive back into accepted_harvested,
         # classify must remove it from the additive corpus.
         (tmp_path / "data").mkdir(parents=True)
+        run_id = "run-123"
         existing = pd.DataFrame([
             {
                 "title": "Dropped Paper", "authors": "A", "year": "2024", "venue": "IEEE",
@@ -397,6 +398,7 @@ class TestClassify:
         accepted = pd.DataFrame([{
             "title": "New Paper", "authors": "C", "year": "2025", "venue": "IEEE",
             "doi": "10.1/new", "abstract": "new abstract", "source_url": "", "citation_count": 50,
+            "rescore_run_id": run_id,
         }])
         accepted.to_csv(tmp_path / "data" / "accepted_harvested.csv", index=False)
         rescored = pd.DataFrame([
@@ -404,11 +406,96 @@ class TestClassify:
                 "title": "Dropped Paper", "authors": "A", "year": "2024", "venue": "IEEE",
                 "doi": "10.1/drop", "abstract": "newly rescored abstract", "source_url": "",
                 "citation_count": 10, "total_quality_score": 20.0, "is_preprint": False,
+                "rescore_run_id": run_id,
             },
             {
                 "title": "New Paper", "authors": "C", "year": "2025", "venue": "IEEE",
                 "doi": "10.1/new", "abstract": "new abstract", "source_url": "",
                 "citation_count": 50, "total_quality_score": 80.0, "is_preprint": False,
+                "rescore_run_id": run_id,
+            },
+        ])
+        rescored.to_csv(tmp_path / "data" / "rescore_metrics.csv", index=False)
+        (tmp_path / "data" / ".rescore_window.json").write_text(json.dumps({"run_id": run_id}))
+
+        with patch("alex.utils.io.ROOT", tmp_path), \
+             patch("alex.utils.io.DATA_DIR", tmp_path / "data"), \
+             patch("alex.utils.io.CONFIG_DIR", tmp_path / "config"), \
+             patch.dict("os.environ", {"OPENAI_API_KEY": ""}, clear=False):
+            from alex.pipelines import classify
+            classify.run()
+
+        result = pd.read_csv(tmp_path / "data" / "accepted_classified.csv")
+        dois = set(result["doi"].astype(str).tolist())
+        assert dois == {"10.1/keep", "10.1/new"}
+        assert "10.1/drop" not in dois
+        assert not (tmp_path / "data" / ".rescore_window.json").exists()
+
+    def test_classify_empty_accepts_can_still_prune_rescored_out_rows(self, tmp_path):
+        # If rescore rejects everything this run, classify still needs to prune
+        # the current window from the existing corpus rather than returning
+        # early and leaving stale rows published.
+        (tmp_path / "data").mkdir(parents=True)
+        run_id = "run-456"
+        existing = pd.DataFrame([{
+            "title": "Dropped Paper", "authors": "A", "year": "2024", "venue": "IEEE",
+            "doi": "10.1/drop", "abstract": "old abstract", "source_url": "", "citation_count": 10,
+            "Category": "Old", "Investigation_Type": "", "OSINT_Source_Types": "",
+            "Keywords": "", "Tags": "", "Quality_Tier": "Standard", "Seminal_Flag": "FALSE",
+        }])
+        existing.to_csv(tmp_path / "data" / "accepted_classified.csv", index=False)
+        pd.DataFrame(columns=["title", "rescore_run_id"]).to_csv(
+            tmp_path / "data" / "accepted_harvested.csv", index=False
+        )
+        rescored = pd.DataFrame([{
+            "title": "Dropped Paper", "authors": "A", "year": "2024", "venue": "IEEE",
+            "doi": "10.1/drop", "abstract": "newly rescored abstract", "source_url": "",
+            "citation_count": 10, "total_quality_score": 20.0, "is_preprint": False,
+            "rescore_run_id": run_id,
+        }])
+        rescored.to_csv(tmp_path / "data" / "rescore_metrics.csv", index=False)
+        (tmp_path / "data" / ".rescore_window.json").write_text(json.dumps({"run_id": run_id}))
+
+        with patch("alex.utils.io.ROOT", tmp_path), \
+             patch("alex.utils.io.DATA_DIR", tmp_path / "data"), \
+             patch("alex.utils.io.CONFIG_DIR", tmp_path / "config"), \
+             patch.dict("os.environ", {"OPENAI_API_KEY": ""}, clear=False):
+            from alex.pipelines import classify
+            classify.run()
+
+        result = pd.read_csv(tmp_path / "data" / "accepted_classified.csv")
+        assert result.empty
+
+    def test_classify_ignores_stale_rescore_metrics_without_window_token(self, tmp_path):
+        # Manual classify runs should not prune against a stale metrics file if
+        # the current rescore window token is absent.
+        (tmp_path / "data").mkdir(parents=True)
+        existing = pd.DataFrame([
+            {
+                "title": "Historical Paper", "authors": "B", "year": "2023", "venue": "USENIX",
+                "doi": "10.1/keep", "abstract": "historical abstract", "source_url": "", "citation_count": 5,
+                "Category": "Seed", "Investigation_Type": "", "OSINT_Source_Types": "",
+                "Keywords": "", "Tags": "", "Quality_Tier": "Standard", "Seminal_Flag": "FALSE",
+            },
+            {
+                "title": "Dropped Paper", "authors": "A", "year": "2024", "venue": "IEEE",
+                "doi": "10.1/drop", "abstract": "old abstract", "source_url": "", "citation_count": 10,
+                "Category": "Old", "Investigation_Type": "", "OSINT_Source_Types": "",
+                "Keywords": "", "Tags": "", "Quality_Tier": "Standard", "Seminal_Flag": "FALSE",
+            },
+        ])
+        existing.to_csv(tmp_path / "data" / "accepted_classified.csv", index=False)
+        accepted = pd.DataFrame([{
+            "title": "New Paper", "authors": "C", "year": "2025", "venue": "IEEE",
+            "doi": "10.1/new", "abstract": "new abstract", "source_url": "", "citation_count": 50,
+        }])
+        accepted.to_csv(tmp_path / "data" / "accepted_harvested.csv", index=False)
+        rescored = pd.DataFrame([
+            {
+                "title": "Dropped Paper", "authors": "A", "year": "2024", "venue": "IEEE",
+                "doi": "10.1/drop", "abstract": "newly rescored abstract", "source_url": "",
+                "citation_count": 10, "total_quality_score": 20.0, "is_preprint": False,
+                "rescore_run_id": "stale-run",
             },
         ])
         rescored.to_csv(tmp_path / "data" / "rescore_metrics.csv", index=False)
@@ -422,38 +509,7 @@ class TestClassify:
 
         result = pd.read_csv(tmp_path / "data" / "accepted_classified.csv")
         dois = set(result["doi"].astype(str).tolist())
-        assert dois == {"10.1/keep", "10.1/new"}
-        assert "10.1/drop" not in dois
-
-    def test_classify_empty_accepts_can_still_prune_rescored_out_rows(self, tmp_path):
-        # If rescore rejects everything this run, classify still needs to prune
-        # the current window from the existing corpus rather than returning
-        # early and leaving stale rows published.
-        (tmp_path / "data").mkdir(parents=True)
-        existing = pd.DataFrame([{
-            "title": "Dropped Paper", "authors": "A", "year": "2024", "venue": "IEEE",
-            "doi": "10.1/drop", "abstract": "old abstract", "source_url": "", "citation_count": 10,
-            "Category": "Old", "Investigation_Type": "", "OSINT_Source_Types": "",
-            "Keywords": "", "Tags": "", "Quality_Tier": "Standard", "Seminal_Flag": "FALSE",
-        }])
-        existing.to_csv(tmp_path / "data" / "accepted_classified.csv", index=False)
-        pd.DataFrame().to_csv(tmp_path / "data" / "accepted_harvested.csv", index=False)
-        rescored = pd.DataFrame([{
-            "title": "Dropped Paper", "authors": "A", "year": "2024", "venue": "IEEE",
-            "doi": "10.1/drop", "abstract": "newly rescored abstract", "source_url": "",
-            "citation_count": 10, "total_quality_score": 20.0, "is_preprint": False,
-        }])
-        rescored.to_csv(tmp_path / "data" / "rescore_metrics.csv", index=False)
-
-        with patch("alex.utils.io.ROOT", tmp_path), \
-             patch("alex.utils.io.DATA_DIR", tmp_path / "data"), \
-             patch("alex.utils.io.CONFIG_DIR", tmp_path / "config"), \
-             patch.dict("os.environ", {"OPENAI_API_KEY": ""}, clear=False):
-            from alex.pipelines import classify
-            classify.run()
-
-        result = pd.read_csv(tmp_path / "data" / "accepted_classified.csv")
-        assert result.empty
+        assert dois == {"10.1/keep", "10.1/drop", "10.1/new"}
 
 
 class TestHarvest:
@@ -630,6 +686,7 @@ class TestRescore:
         assert (tmp_path / "data" / "rescore_metrics.csv").exists()
         metrics = pd.read_csv(tmp_path / "data" / "rescore_metrics.csv")
         assert metrics.empty
+        assert not (tmp_path / "data" / ".rescore_window.json").exists()
 
     def test_filters_to_auto_include_tier(self, tmp_path):
         # Two rows: one that meets the regular auto-include with full abstract,
@@ -656,10 +713,14 @@ class TestRescore:
             rescore.run()
 
         accepted = pd.read_csv(tmp_path / "data" / "accepted_harvested.csv")
+        metrics = pd.read_csv(tmp_path / "data" / "rescore_metrics.csv")
+        token = json.loads((tmp_path / "data" / ".rescore_window.json").read_text())
+        assert accepted.iloc[0]["rescore_run_id"] == token["run_id"]
+        assert metrics["rescore_run_id"].nunique() == 1
+        assert metrics["rescore_run_id"].iloc[0] == token["run_id"]
         assert len(accepted) == 1
         assert "OSINT" in accepted.iloc[0]["title"]
         # rescore_metrics keeps both rows for audit
-        metrics = pd.read_csv(tmp_path / "data" / "rescore_metrics.csv")
         assert len(metrics) == 2
 
     def test_preprint_threshold_applied(self, tmp_path):
@@ -682,5 +743,9 @@ class TestRescore:
             rescore.run()
 
         accepted = pd.read_csv(tmp_path / "data" / "accepted_harvested.csv")
+        metrics = pd.read_csv(tmp_path / "data" / "rescore_metrics.csv")
+        token = json.loads((tmp_path / "data" / ".rescore_window.json").read_text())
         assert len(accepted) == 1
         assert bool(accepted.iloc[0]["is_preprint"]) is True
+        assert accepted.iloc[0]["rescore_run_id"] == token["run_id"]
+        assert metrics["rescore_run_id"].iloc[0] == token["run_id"]

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -2,7 +2,7 @@ import json
 import pytest
 from unittest.mock import patch, MagicMock
 import pandas as pd
-from alex.pipelines import quality_gate, publish
+from alex.pipelines import quality_gate, publish, rescore
 from alex.utils.io import validate_columns
 
 
@@ -31,6 +31,7 @@ class TestQualityGate:
             "venue": 0.35, "citations": 0.40, "relevance": 0.25,
             "institution_bonus": 10.0,
             "auto_include_threshold": 75.0, "review_threshold": 45.0,
+            "preprint_auto_include_threshold": 35.0, "preprint_review_threshold": 20.0,
         }))
 
         with patch("alex.utils.io.ROOT", tmp_path), \
@@ -47,11 +48,65 @@ class TestQualityGate:
         assert len(metrics) == 2
         assert "candidate_id" in metrics.columns
         assert "scored_at" in metrics.columns
-        assert len(accepted) + len(review) + len(rejected) == 2
+        # accepted_candidates.csv is the enrichment pool (auto-include + review);
+        # review_queue.csv is a subset. Every row ends up in either
+        # enrichment-pool OR rejected.
+        assert len(accepted) + len(rejected) == 2
+        if len(review) > 0:
+            assert set(review["title"]).issubset(set(accepted["title"]))
         # The IEEE paper with high citations from MIT should score highest
         high_score = metrics.loc[metrics["title"].str.contains("High Quality"), "total_quality_score"].iloc[0]
         low_score = metrics.loc[metrics["title"].str.contains("Mediocre"), "total_quality_score"].iloc[0]
         assert high_score > low_score
+
+    def test_preprint_routing_uses_separate_thresholds(self, tmp_path):
+        """arXiv papers route on lower preprint thresholds so they don't
+        get penalised for the structural lack of venue/citation signal."""
+        # Two near-identical rows differing only in discovery_source. The
+        # relevance-heavy arXiv preprint should auto-include under preprint
+        # thresholds; the same content from a non-preprint source should
+        # not reach the regular threshold.
+        candidates = pd.DataFrame([
+            {"title": "OSINT methodology", "authors": "A", "year": "2025",
+             "venue": "arXiv", "doi": "", "abstract": "OSINT cybersecurity",
+             "source_url": "", "discovery_source": "arXiv RSS",
+             "discovery_query": "OSINT", "inclusion_path": "discovery",
+             "citation_count": 0, "reference_count": 0},
+            {"title": "OSINT methodology elsewhere", "authors": "A", "year": "2025",
+             "venue": "Unknown Journal", "doi": "", "abstract": "OSINT cybersecurity",
+             "source_url": "", "discovery_source": "OpenAlex",
+             "discovery_query": "OSINT", "inclusion_path": "discovery",
+             "citation_count": 0, "reference_count": 0},
+        ])
+        (tmp_path / "data").mkdir(parents=True)
+        candidates.to_csv(tmp_path / "data" / "discovery_candidates.csv", index=False)
+
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        (config_dir / "venue_whitelist.json").write_text(json.dumps({"high_trust": ["IEEE"]}))
+        (config_dir / "query_registry.json").write_text(json.dumps({"queries": ["OSINT", "cybersecurity"]}))
+        (config_dir / "quality_weights.json").write_text(json.dumps({
+            "venue": 0.35, "citations": 0.40, "relevance": 0.25,
+            "institution_bonus": 10.0,
+            "auto_include_threshold": 75.0, "review_threshold": 45.0,
+            "preprint_auto_include_threshold": 35.0, "preprint_review_threshold": 20.0,
+        }))
+
+        with patch("alex.utils.io.ROOT", tmp_path), \
+             patch("alex.utils.io.DATA_DIR", tmp_path / "data"), \
+             patch("alex.utils.io.CONFIG_DIR", tmp_path / "config"):
+            quality_gate.run()
+
+        metrics = pd.read_csv(tmp_path / "data" / "quality_metrics.csv")
+        preprint_row = metrics[metrics["discovery_source"] == "arXiv RSS"].iloc[0]
+        non_preprint_row = metrics[metrics["discovery_source"] == "OpenAlex"].iloc[0]
+
+        assert bool(preprint_row["is_preprint"]) is True
+        assert bool(non_preprint_row["is_preprint"]) is False
+        # Same total (same venue+citation+relevance signal), different routing
+        assert preprint_row["total_quality_score"] == non_preprint_row["total_quality_score"]
+        assert preprint_row["recommended_action"] == "auto-include"
+        assert non_preprint_row["recommended_action"] in ("human review", "reject")
 
 
 class TestPublish:
@@ -462,3 +517,83 @@ class TestDiscoveryAbstractEnrichment:
             _enrich_missing_abstracts(rows, client=MagicMock(), mailto="")
 
         assert rows[0]["abstract"] == ""
+
+
+class TestRescore:
+    def _setup_config(self, tmp_path):
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        (config_dir / "venue_whitelist.json").write_text(json.dumps({"high_trust": ["IEEE"]}))
+        (config_dir / "query_registry.json").write_text(json.dumps({"queries": ["OSINT", "cybersecurity"]}))
+        (config_dir / "quality_weights.json").write_text(json.dumps({
+            "venue": 0.35, "citations": 0.40, "relevance": 0.25,
+            "institution_bonus": 10.0,
+            "auto_include_threshold": 75.0, "review_threshold": 45.0,
+            "preprint_auto_include_threshold": 35.0, "preprint_review_threshold": 20.0,
+        }))
+
+    def test_empty_input_preserves_existing(self, tmp_path):
+        # No harvested file -> create empty and return (matches pattern of
+        # the rest of the pipeline's empty-input handling).
+        (tmp_path / "data").mkdir(parents=True)
+        self._setup_config(tmp_path)
+        with patch("alex.utils.io.ROOT", tmp_path), \
+             patch("alex.utils.io.DATA_DIR", tmp_path / "data"), \
+             patch("alex.utils.io.CONFIG_DIR", tmp_path / "config"):
+            rescore.run()
+        # No harvested file existed; rescore shouldn't create spurious outputs.
+        assert not (tmp_path / "data" / "rescore_metrics.csv").exists()
+
+    def test_filters_to_auto_include_tier(self, tmp_path):
+        # Two rows: one that meets the regular auto-include with full abstract,
+        # one that falls below and should drop out after rescoring.
+        harvested = pd.DataFrame([
+            {"title": "OSINT methodology and cybersecurity",
+             "authors": "A", "year": "2025", "venue": "IEEE S&P",
+             "doi": "10.1/x", "abstract": "OSINT methodology cybersecurity",
+             "source_url": "", "discovery_source": "OpenAlex",
+             "citation_count": 200, "is_preprint": False},
+            {"title": "Unrelated cooking recipes",
+             "authors": "B", "year": "2025", "venue": "Food Journal",
+             "doi": "10.1/y", "abstract": "broccoli and cheese",
+             "source_url": "", "discovery_source": "OpenAlex",
+             "citation_count": 0, "is_preprint": False},
+        ])
+        (tmp_path / "data").mkdir(parents=True)
+        harvested.to_csv(tmp_path / "data" / "accepted_harvested.csv", index=False)
+        self._setup_config(tmp_path)
+
+        with patch("alex.utils.io.ROOT", tmp_path), \
+             patch("alex.utils.io.DATA_DIR", tmp_path / "data"), \
+             patch("alex.utils.io.CONFIG_DIR", tmp_path / "config"):
+            rescore.run()
+
+        accepted = pd.read_csv(tmp_path / "data" / "accepted_harvested.csv")
+        assert len(accepted) == 1
+        assert "OSINT" in accepted.iloc[0]["title"]
+        # rescore_metrics keeps both rows for audit
+        metrics = pd.read_csv(tmp_path / "data" / "rescore_metrics.csv")
+        assert len(metrics) == 2
+
+    def test_preprint_threshold_applied(self, tmp_path):
+        # An arXiv preprint with no citations but relevant title clears the
+        # preprint threshold even though it wouldn't clear the regular one.
+        harvested = pd.DataFrame([{
+            "title": "OSINT cybersecurity methodology",
+            "authors": "A", "year": "2025", "venue": "arXiv",
+            "doi": "", "abstract": "OSINT investigation cybersecurity",
+            "source_url": "", "discovery_source": "arXiv RSS",
+            "citation_count": 0, "is_preprint": True,
+        }])
+        (tmp_path / "data").mkdir(parents=True)
+        harvested.to_csv(tmp_path / "data" / "accepted_harvested.csv", index=False)
+        self._setup_config(tmp_path)
+
+        with patch("alex.utils.io.ROOT", tmp_path), \
+             patch("alex.utils.io.DATA_DIR", tmp_path / "data"), \
+             patch("alex.utils.io.CONFIG_DIR", tmp_path / "config"):
+            rescore.run()
+
+        accepted = pd.read_csv(tmp_path / "data" / "accepted_harvested.csv")
+        assert len(accepted) == 1
+        assert bool(accepted.iloc[0]["is_preprint"]) is True

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -371,6 +371,90 @@ class TestClassify:
         assert len(result) == 1  # deduped
         assert result.iloc[0]["title"] == "Updated Title"  # new won
 
+    def test_classify_prunes_rows_rescored_out_this_run(self, tmp_path):
+        # If a previously published paper is reconsidered by the current
+        # rescore window but does not survive back into accepted_harvested,
+        # classify must remove it from the additive corpus.
+        (tmp_path / "data").mkdir(parents=True)
+        existing = pd.DataFrame([
+            {
+                "title": "Dropped Paper", "authors": "A", "year": "2024", "venue": "IEEE",
+                "doi": "10.1/drop", "abstract": "old abstract", "source_url": "", "citation_count": 10,
+                "Category": "Old", "Investigation_Type": "", "OSINT_Source_Types": "",
+                "Keywords": "", "Tags": "", "Quality_Tier": "Standard", "Seminal_Flag": "FALSE",
+            },
+            {
+                "title": "Historical Paper", "authors": "B", "year": "2023", "venue": "USENIX",
+                "doi": "10.1/keep", "abstract": "historical abstract", "source_url": "", "citation_count": 5,
+                "Category": "Seed", "Investigation_Type": "", "OSINT_Source_Types": "",
+                "Keywords": "", "Tags": "", "Quality_Tier": "Standard", "Seminal_Flag": "FALSE",
+            },
+        ])
+        existing.to_csv(tmp_path / "data" / "accepted_classified.csv", index=False)
+
+        # The current rescore window reconsidered Dropped Paper but rejected it,
+        # while newly accepting New Paper.
+        accepted = pd.DataFrame([{
+            "title": "New Paper", "authors": "C", "year": "2025", "venue": "IEEE",
+            "doi": "10.1/new", "abstract": "new abstract", "source_url": "", "citation_count": 50,
+        }])
+        accepted.to_csv(tmp_path / "data" / "accepted_harvested.csv", index=False)
+        rescored = pd.DataFrame([
+            {
+                "title": "Dropped Paper", "authors": "A", "year": "2024", "venue": "IEEE",
+                "doi": "10.1/drop", "abstract": "newly rescored abstract", "source_url": "",
+                "citation_count": 10, "total_quality_score": 20.0, "is_preprint": False,
+            },
+            {
+                "title": "New Paper", "authors": "C", "year": "2025", "venue": "IEEE",
+                "doi": "10.1/new", "abstract": "new abstract", "source_url": "",
+                "citation_count": 50, "total_quality_score": 80.0, "is_preprint": False,
+            },
+        ])
+        rescored.to_csv(tmp_path / "data" / "rescore_metrics.csv", index=False)
+
+        with patch("alex.utils.io.ROOT", tmp_path), \
+             patch("alex.utils.io.DATA_DIR", tmp_path / "data"), \
+             patch("alex.utils.io.CONFIG_DIR", tmp_path / "config"), \
+             patch.dict("os.environ", {"OPENAI_API_KEY": ""}, clear=False):
+            from alex.pipelines import classify
+            classify.run()
+
+        result = pd.read_csv(tmp_path / "data" / "accepted_classified.csv")
+        dois = set(result["doi"].astype(str).tolist())
+        assert dois == {"10.1/keep", "10.1/new"}
+        assert "10.1/drop" not in dois
+
+    def test_classify_empty_accepts_can_still_prune_rescored_out_rows(self, tmp_path):
+        # If rescore rejects everything this run, classify still needs to prune
+        # the current window from the existing corpus rather than returning
+        # early and leaving stale rows published.
+        (tmp_path / "data").mkdir(parents=True)
+        existing = pd.DataFrame([{
+            "title": "Dropped Paper", "authors": "A", "year": "2024", "venue": "IEEE",
+            "doi": "10.1/drop", "abstract": "old abstract", "source_url": "", "citation_count": 10,
+            "Category": "Old", "Investigation_Type": "", "OSINT_Source_Types": "",
+            "Keywords": "", "Tags": "", "Quality_Tier": "Standard", "Seminal_Flag": "FALSE",
+        }])
+        existing.to_csv(tmp_path / "data" / "accepted_classified.csv", index=False)
+        pd.DataFrame().to_csv(tmp_path / "data" / "accepted_harvested.csv", index=False)
+        rescored = pd.DataFrame([{
+            "title": "Dropped Paper", "authors": "A", "year": "2024", "venue": "IEEE",
+            "doi": "10.1/drop", "abstract": "newly rescored abstract", "source_url": "",
+            "citation_count": 10, "total_quality_score": 20.0, "is_preprint": False,
+        }])
+        rescored.to_csv(tmp_path / "data" / "rescore_metrics.csv", index=False)
+
+        with patch("alex.utils.io.ROOT", tmp_path), \
+             patch("alex.utils.io.DATA_DIR", tmp_path / "data"), \
+             patch("alex.utils.io.CONFIG_DIR", tmp_path / "config"), \
+             patch.dict("os.environ", {"OPENAI_API_KEY": ""}, clear=False):
+            from alex.pipelines import classify
+            classify.run()
+
+        result = pd.read_csv(tmp_path / "data" / "accepted_classified.csv")
+        assert result.empty
+
 
 class TestHarvest:
     def test_harvest_crossref_fallback(self, tmp_path):
@@ -541,8 +625,11 @@ class TestRescore:
              patch("alex.utils.io.DATA_DIR", tmp_path / "data"), \
              patch("alex.utils.io.CONFIG_DIR", tmp_path / "config"):
             rescore.run()
-        # No harvested file existed; rescore shouldn't create spurious outputs.
-        assert not (tmp_path / "data" / "rescore_metrics.csv").exists()
+        # Even on an empty run, emit the metrics placeholder so workflow
+        # `git add` steps do not fail on a missing path.
+        assert (tmp_path / "data" / "rescore_metrics.csv").exists()
+        metrics = pd.read_csv(tmp_path / "data" / "rescore_metrics.csv")
+        assert metrics.empty
 
     def test_filters_to_auto_include_tier(self, tmp_path):
         # Two rows: one that meets the regular auto-include with full abstract,


### PR DESCRIPTION
## Summary
- add a post-harvest `rescore` pipeline stage between harvest and classify
- route preprints through separate quality thresholds and keep review-tier papers in the enrichment pool until rescoring
- cover the new routing and rescoring behavior in pipeline tests

## Testing
- `uv run pytest tests/test_pipelines.py -q`
