### PR TITLE
Apply Semantic Scholar gate to citation_chain (regression follow-up to #45)

### DIFF
--- a/alex/connectors/semantic_scholar.py
+++ b/alex/connectors/semantic_scholar.py
@@ -87,11 +87,18 @@ def _year_in_window(year: Any, from_date: str, until_date: str) -> bool:
 PAPER = "https://api.semanticscholar.org/graph/v1/paper"
 
 
-def get_paper(client: HttpClient, paper_id: str) -> dict[str, Any] | None:
-    """Fetch a single paper by Semantic Scholar paper ID."""
+def get_paper(client: HttpClient, paper_id: str, *, api_key: str = "") -> dict[str, Any] | None:
+    """Fetch a single paper by Semantic Scholar paper ID.
+
+    Pass `api_key` to send the `x-api-key` header — without it the public
+    tier 429s on every call within seconds, which the HttpClient retry
+    layer turns into ~7s of wasted backoff per call.
+    """
+    headers = {"x-api-key": api_key} if api_key else None
     data = client.get_json(
         f"{PAPER}/{paper_id}",
         params={"fields": "title,abstract,authors,venue,year,citationCount,externalIds,url"},
+        headers=headers,
     )
     return data
 

--- a/alex/pipelines/citation_chain.py
+++ b/alex/pipelines/citation_chain.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
+import logging
 import os
 import pandas as pd
 from alex.utils.io import load_df, save_df, root_file
 from alex.utils.http import HttpClient
 from alex.utils.text import normalize_title, clean
+from alex.utils import connector_config
 from alex.connectors import openalex, semantic_scholar
+
+logger = logging.getLogger(__name__)
+
 
 def run() -> None:
     client = HttpClient(mailto=os.getenv("HARVEST_MAILTO", ""))
@@ -12,6 +17,22 @@ def run() -> None:
     if df.empty:
         print("No discovery candidates to citation-chain.")
         return
+
+    # Honour the connectors gate. S2 backward chaining issues up to 16 calls
+    # per candidate (1 search + 5 references × 3 results); without an API key
+    # every one hits 429 and the HttpClient retry layer turns each into a
+    # ~7s backoff burn. With ~100 candidates that's hours wasted before we
+    # bail. Gate it the same way discovery and harvest do.
+    config = connector_config.load()
+    s2_key = os.getenv("SEMANTIC_SCHOLAR_API_KEY", "")
+    enable_s2 = connector_config.is_enabled(config, "semantic_scholar", default=False)
+    if enable_s2 and not s2_key:
+        logger.warning(
+            "Citation chain: Semantic Scholar enabled in config but "
+            "SEMANTIC_SCHOLAR_API_KEY is unset; skipping backward-chaining "
+            "via S2 (forward chaining via OpenAlex still runs)."
+        )
+        enable_s2 = False
 
     rows = []
     seen = set(normalize_title(str(t)) for t in df["title"].tolist())
@@ -46,13 +67,15 @@ def run() -> None:
                         "reference_count": len(cited.get("referenced_works") or []),
                     })
         # Semantic Scholar backward chaining
-        ss_results = semantic_scholar.search(client, title, limit=3)
+        if not enable_s2:
+            continue
+        ss_results = semantic_scholar.search(client, title, api_key=s2_key, limit=3)
         for item in ss_results:
             for ref in semantic_scholar.references(item)[:5]:
                 pid = ref.get("paperId")
                 if not pid:
                     continue
-                paper = semantic_scholar.get_paper(client, pid)
+                paper = semantic_scholar.get_paper(client, pid, api_key=s2_key)
                 if not paper or not paper.get("title"):
                     continue
                 rt = clean(paper["title"])

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -942,6 +942,76 @@ class TestDiscoveryConnectorGating:
         assert core_mock.call_count == 2
 
 
+class TestCitationChainConnectorGating:
+    """Citation chain must honour the same S2 gate as discovery and harvest.
+    Backward chaining via S2 issues up to 16 calls per candidate; without an
+    API key those all 429 and the retry layer multiplies the burn."""
+
+    def _candidates_csv(self, tmp_path):
+        df = pd.DataFrame([{
+            "title": "Seed paper", "authors": "", "year": "2024",
+            "venue": "", "doi": "", "abstract": "", "source_url": "",
+            "discovery_source": "test", "discovery_query": "test",
+            "inclusion_path": "discovery", "citation_count": 100,
+            "reference_count": 0,
+        }])
+        (tmp_path / "data").mkdir(parents=True, exist_ok=True)
+        df.to_csv(tmp_path / "data" / "discovery_candidates.csv", index=False)
+
+    def test_skips_s2_when_disabled_in_config(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SEMANTIC_SCHOLAR_API_KEY", "k_test")
+        self._candidates_csv(tmp_path)
+        with patch("alex.utils.io.ROOT", tmp_path), \
+             patch("alex.utils.io.DATA_DIR", tmp_path / "data"), \
+             patch("alex.utils.io.CONFIG_DIR", tmp_path / "config"), \
+             patch("alex.pipelines.citation_chain.connector_config.load",
+                   return_value={"connectors": {"semantic_scholar": {"enabled": False}}}), \
+             patch("alex.connectors.openalex.search", return_value=[]), \
+             patch("alex.connectors.openalex.fetch_cited_by", return_value=[]), \
+             patch("alex.connectors.semantic_scholar.search") as s2_search, \
+             patch("alex.connectors.semantic_scholar.get_paper") as s2_paper, \
+             patch("alex.pipelines.citation_chain.HttpClient"):
+            from alex.pipelines import citation_chain
+            citation_chain.run()
+        s2_search.assert_not_called()
+        s2_paper.assert_not_called()
+
+    def test_skips_s2_when_enabled_but_no_key(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SEMANTIC_SCHOLAR_API_KEY", raising=False)
+        self._candidates_csv(tmp_path)
+        with patch("alex.utils.io.ROOT", tmp_path), \
+             patch("alex.utils.io.DATA_DIR", tmp_path / "data"), \
+             patch("alex.utils.io.CONFIG_DIR", tmp_path / "config"), \
+             patch("alex.pipelines.citation_chain.connector_config.load",
+                   return_value={"connectors": {"semantic_scholar": {"enabled": True}}}), \
+             patch("alex.connectors.openalex.search", return_value=[]), \
+             patch("alex.connectors.openalex.fetch_cited_by", return_value=[]), \
+             patch("alex.connectors.semantic_scholar.search") as s2_search, \
+             patch("alex.connectors.semantic_scholar.get_paper") as s2_paper, \
+             patch("alex.pipelines.citation_chain.HttpClient"):
+            from alex.pipelines import citation_chain
+            citation_chain.run()
+        s2_search.assert_not_called()
+        s2_paper.assert_not_called()
+
+    def test_calls_s2_with_key_when_enabled(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SEMANTIC_SCHOLAR_API_KEY", "k_test")
+        self._candidates_csv(tmp_path)
+        with patch("alex.utils.io.ROOT", tmp_path), \
+             patch("alex.utils.io.DATA_DIR", tmp_path / "data"), \
+             patch("alex.utils.io.CONFIG_DIR", tmp_path / "config"), \
+             patch("alex.pipelines.citation_chain.connector_config.load",
+                   return_value={"connectors": {"semantic_scholar": {"enabled": True}}}), \
+             patch("alex.connectors.openalex.search", return_value=[]), \
+             patch("alex.connectors.openalex.fetch_cited_by", return_value=[]), \
+             patch("alex.connectors.semantic_scholar.search", return_value=[]) as s2_search, \
+             patch("alex.pipelines.citation_chain.HttpClient"):
+            from alex.pipelines import citation_chain
+            citation_chain.run()
+        s2_search.assert_called()
+        assert s2_search.call_args.kwargs.get("api_key") == "k_test"
+
+
 class TestRescore:
     def _setup_config(self, tmp_path):
         config_dir = tmp_path / "config"


### PR DESCRIPTION
Follow-up to #45 / PR #46.

## Problem

The new \`HttpClient\` retry layer from #45 (1+2+4s backoff on 429/5xx) **amplified citation_chain's S2 cost badly**. Per candidate, backward chaining issues:

- 1 S2 title search
- up to 5 references × 3 results = up to 15 \`get_paper\` calls

→ **up to 16 S2 calls per candidate**. With 100 candidates that's ~1600 S2 calls. Without an API key all hit 429, and with the new retry each call burns ~7s of backoff instead of the prior ~0.5s polite delay. **~18× slowdown.**

A manual Pipeline run on main ([24902188532](https://github.com/RISEInfoSec/Alex/actions/runs/24902188532)) showed citation_chain at **44m 44s** — vs. minutes pre-#45 on a comparable window.

## Fix

Same pattern as discovery (#46) and harvest:

- \`citation_chain.run()\` reads the connectors gate via \`connector_config.load()\`
- If S2 is disabled in config (default) **or** enabled without \`SEMANTIC_SCHOLAR_API_KEY\`, the S2 backward-chaining block is skipped entirely
- Forward chaining via OpenAlex \`cited_by\` is unaffected — still runs
- \`semantic_scholar.get_paper\` now accepts \`api_key=\` so the call goes out keyed when the gate allows

## Test plan

- [x] \`test_skips_s2_when_disabled_in_config\` — S2 calls never happen
- [x] \`test_skips_s2_when_enabled_but_no_key\` — same, key absent
- [x] \`test_calls_s2_with_key_when_enabled\` — verifies \`api_key\` is passed through
- [x] Existing 175 tests still pass; total now 178 passing

## Out of scope (worth a separate issue)

The S2 reference fan-out (5 refs × 3 results = 15 calls per candidate) is aggressive even with a key. Worth making configurable in a follow-up — but this PR addresses the urgent regression first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)