### PR TITLE
Pipeline: rebase-and-retry on push rejection

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -36,7 +36,7 @@ jobs:
           python -m alex.cli discover
           git add data/discovery_candidates.csv
           git diff --cached --quiet || git commit -m "Discover candidates"
-          git push
+          git push || (git pull --rebase --autostash && git push)
       - name: Citation chain
         env:
           HARVEST_MAILTO: ${{ secrets.HARVEST_MAILTO }}
@@ -44,13 +44,13 @@ jobs:
           python -m alex.cli chain
           git add data/discovery_candidates.csv
           git diff --cached --quiet || git commit -m "Citation chain candidates"
-          git push
+          git push || (git pull --rebase --autostash && git push)
       - name: Quality gate
         run: |
           python -m alex.cli score
           git add data/quality_metrics.csv data/review_queue.csv data/rejected_candidates.csv data/accepted_candidates.csv
           git diff --cached --quiet || git commit -m "Quality gate results"
-          git push
+          git push || (git pull --rebase --autostash && git push)
       - name: Harvest
         env:
           HARVEST_MAILTO: ${{ secrets.HARVEST_MAILTO }}
@@ -58,14 +58,14 @@ jobs:
           python -m alex.cli harvest
           git add data/accepted_harvested.csv
           git diff --cached --quiet || git commit -m "Harvest metadata"
-          git push
+          git push || (git pull --rebase --autostash && git push)
       - name: Rescore
         run: |
           SUMMARY=$(python -m alex.cli rescore | tail -n1)
           echo "$SUMMARY"
           git add data/accepted_harvested.csv data/rescore_metrics.csv
           git diff --cached --quiet || git commit -m "Post-harvest rescore: ${SUMMARY:-no summary}"
-          git push
+          git push || (git pull --rebase --autostash && git push)
       - name: Classify
         env:
           OPENAI_API_KEY: ${{ secrets.OPEN_API_KEY }}
@@ -74,13 +74,13 @@ jobs:
           python -m alex.cli classify
           git add data/accepted_classified.csv
           git diff --cached --quiet || git commit -m "Classify accepted papers"
-          git push
+          git push || (git pull --rebase --autostash && git push)
       - name: Publish
         run: |
           python -m alex.cli publish
           git add data/osint_cyber_papers.csv data/papers.json
           git diff --cached --quiet || git commit -m "Publish public corpus"
-          git push
+          git push || (git pull --rebase --autostash && git push)
   deploy:
     # Pages deploy in a separate job so it can run under the github-pages
     # environment. Checks out main after the pipeline job's pushes so the


### PR DESCRIPTION
## Why

Pipeline run [24902188532](https://github.com/RISEInfoSec/Alex/actions/runs/24902188532) failed in Harvest with:

\`\`\`
! [rejected]        main -> main (fetch first)
error: failed to push some refs to 'https://github.com/RISEInfoSec/Alex'
\`\`\`

Root cause: main advanced during the workflow's ~2-hour run (PRs #46 and #48 merged at 17:09 and 18:09 UTC; Harvest tried to push at 19:13). The pipeline has **seven** \`git push\` calls across stages — any of them is vulnerable to the same race whenever an external commit (human merge, another workflow) lands on main mid-run.

Critically, this isn't a logic bug — it's a workflow-design flaw that will keep biting us as the pipeline grows.

## Fix

Replace each \`git push\` with:

\`\`\`bash
git push || (git pull --rebase --autostash && git push)
\`\`\`

If the first push wins (the common case), the rebase never runs — zero overhead. If rejected, rebase the workflow's local commits on top of whatever landed and retry once. The workflow's commits are data-file changes that are independent across stages and from typical code-only PR merges, so a rebase conflict is the edge case rather than the common path.

Concurrency *between* pipeline runs is already serialised by the existing \`concurrency: { group: pipeline }\` block, so the only race remaining was external pushes — which this addresses.

## Scope

Workflow-only change. No code, no tests, no behavioural change unless a push race actually occurs.

## Test plan

- [x] All 7 push points updated (verified via grep)
- [x] YAML syntax still valid (\`yaml.safe_load\` succeeds)
- [ ] First scheduled or manual run after merge will exercise the new path naturally — happy path is unchanged, race path will recover instead of failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)