### PR TITLE
Harvest: skip Crossref for nan/empty/non-Crossref DOIs

### DIFF
--- a/alex/pipelines/harvest.py
+++ b/alex/pipelines/harvest.py
@@ -10,6 +10,19 @@ from alex.utils.text import clean
 
 logger = logging.getLogger(__name__)
 
+# DOI prefixes Crossref does not index — sending these to crossref.get_by_doi
+# always 404s and burns ~1-2s per row in HTTP latency + polite delay. Both
+# Zenodo and arXiv have their own DOI registrars; we have purpose-specific
+# connectors for them elsewhere.
+_NON_CROSSREF_DOI_PREFIXES = ("10.5281/", "10.48550/arxiv")
+
+
+def _is_crossref_indexed_doi(doi: str) -> bool:
+    if not doi:
+        return False
+    lo = doi.lower()
+    return not any(lo.startswith(p) for p in _NON_CROSSREF_DOI_PREFIXES)
+
 
 def run() -> None:
     output_path = root_file("data", "accepted_harvested.csv")
@@ -44,7 +57,7 @@ def run() -> None:
         doi = clean(row.get("doi"))
         best = dict(row)
 
-        if doi:
+        if _is_crossref_indexed_doi(doi):
             cr = crossref.get_by_doi(client, doi)
             if cr:
                 best["doi"] = clean(cr.get("DOI", doi))

--- a/alex/utils/text.py
+++ b/alex/utils/text.py
@@ -4,7 +4,16 @@ from html import unescape
 from typing import Any, Iterable
 
 def clean(v: Any) -> str:
-    return re.sub(r"\s+", " ", str(v or "")).strip()
+    if v is None:
+        return ""
+    # pandas reads empty CSV cells back as float NaN; without this guard
+    # `str(NaN or "")` returns the literal string "nan", which leaks into
+    # every downstream stage (most visibly: harvest sending DOI=nan to
+    # Crossref and getting a 404 per row). `v != v` is the canonical NaN
+    # check that needs no math/pandas import.
+    if isinstance(v, float) and v != v:
+        return ""
+    return re.sub(r"\s+", " ", str(v)).strip()
 
 def normalize_title(title: str) -> str:
     t = clean(title).lower()

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -694,6 +694,63 @@ class TestHarvest:
             harvest.run()
         s2_mock.assert_called()
 
+    def test_skips_crossref_for_zenodo_and_arxiv_dois(self, tmp_path):
+        # Crossref returns 404 for non-Crossref-indexed DOIs (Zenodo,
+        # arXiv); each wasted call costs ~0.5s polite delay + network
+        # latency. The prefix filter short-circuits before the call.
+        accepted = pd.DataFrame([
+            {"title": "Zenodo paper", "authors": "", "year": "2024", "venue": "",
+             "doi": "10.5281/zenodo.1467897", "abstract": "", "source_url": "",
+             "citation_count": 0, "reference_count": 0},
+            {"title": "arXiv paper", "authors": "", "year": "2024", "venue": "",
+             "doi": "10.48550/arxiv.2604.12345", "abstract": "", "source_url": "",
+             "citation_count": 0, "reference_count": 0},
+            {"title": "Real Crossref paper", "authors": "", "year": "2024", "venue": "",
+             "doi": "10.1145/legit.doi", "abstract": "", "source_url": "",
+             "citation_count": 0, "reference_count": 0},
+        ])
+        (tmp_path / "data").mkdir(parents=True)
+        accepted.to_csv(tmp_path / "data" / "accepted_candidates.csv", index=False)
+
+        with patch("alex.utils.io.ROOT", tmp_path), \
+             patch("alex.utils.io.DATA_DIR", tmp_path / "data"), \
+             patch("alex.utils.io.CONFIG_DIR", tmp_path / "config"), \
+             patch("alex.pipelines.harvest.connector_config.load", return_value={}), \
+             patch("alex.connectors.crossref.get_by_doi", return_value=None) as cr_mock, \
+             patch("alex.connectors.openalex.search", return_value=[]), \
+             patch("alex.pipelines.harvest.HttpClient"):
+            from alex.pipelines import harvest
+            harvest.run()
+
+        # Only the legit Crossref-prefix DOI should reach the connector.
+        called_dois = [c.args[1] for c in cr_mock.call_args_list]
+        assert called_dois == ["10.1145/legit.doi"]
+
+    def test_skips_crossref_for_nan_doi_string(self, tmp_path):
+        # Empty CSV cells round-trip through pandas as float NaN; clean()
+        # now returns "" for those, so harvest should not see "nan" reach
+        # the Crossref call. This is the regression test for the bug that
+        # made harvest ~3-5 min slower per run with empty-DOI rows.
+        accepted = pd.DataFrame([{
+            "title": "No DOI paper", "authors": "", "year": "2024",
+            "venue": "", "doi": "", "abstract": "", "source_url": "",
+            "citation_count": 0, "reference_count": 0,
+        }])
+        (tmp_path / "data").mkdir(parents=True)
+        accepted.to_csv(tmp_path / "data" / "accepted_candidates.csv", index=False)
+
+        with patch("alex.utils.io.ROOT", tmp_path), \
+             patch("alex.utils.io.DATA_DIR", tmp_path / "data"), \
+             patch("alex.utils.io.CONFIG_DIR", tmp_path / "config"), \
+             patch("alex.pipelines.harvest.connector_config.load", return_value={}), \
+             patch("alex.connectors.crossref.get_by_doi", return_value=None) as cr_mock, \
+             patch("alex.connectors.openalex.search", return_value=[]), \
+             patch("alex.pipelines.harvest.HttpClient"):
+            from alex.pipelines import harvest
+            harvest.run()
+
+        cr_mock.assert_not_called()
+
 
 class TestDiscoveryAbstractEnrichment:
     def test_enriches_row_missing_abstract_with_doi(self):

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -14,6 +14,26 @@ class TestClean:
     def test_empty_string(self):
         assert clean("") == ""
 
+    def test_nan_float_returns_empty(self):
+        # pandas reads empty CSV cells as float NaN. Without this guard the
+        # literal string "nan" leaked through to downstream stages — most
+        # visibly harvest sending DOI=nan to Crossref and getting a 404.
+        assert clean(float("nan")) == ""
+
+    def test_nan_through_pandas_roundtrip_returns_empty(self):
+        import io
+        import pandas as pd
+        df = pd.DataFrame([{"doi": ""}])
+        roundtripped = pd.read_csv(io.StringIO(df.to_csv(index=False)))
+        assert clean(roundtripped["doi"].iloc[0]) == ""
+
+    def test_zero_still_renders(self):
+        # Guard against the old `str(v or "")` regression where 0 became "".
+        assert clean(0) == "0"
+
+    def test_false_still_renders(self):
+        assert clean(False) == "False"
+
 
 class TestNormalizeTitle:
     def test_lowercases(self):


### PR DESCRIPTION
Follow-up to the post-mortem of run [24902188532](https://github.com/RISEInfoSec/Alex/actions/runs/24902188532). Harvest spent ~3-5 min on doomed Crossref calls.

## Two compounding bugs

### 1. \`clean(float('nan'))\` returned the literal string \`'nan'\`

The old implementation: \`re.sub(r"\s+", " ", str(v or "")).strip()\`. \`NaN or ""\` evaluates \`NaN\` as truthy → stringifies to \`'nan'\`. Empty CSV cells round-trip through pandas as float NaN, so every empty DOI in \`accepted_candidates.csv\` came out of \`clean()\` as the string \`\"nan\"\` and got sent straight to Crossref → 404.

This is **cross-cutting** — every field with empty content (year, citation_count, abstract, ...) was leaking \`\"nan\"\` downstream, not just DOI. DOI was just the most visible symptom.

**Fix:** \`clean()\` now treats NaN as empty using \`v != v\` (canonical NaN check, no math/pandas import).

### 2. Harvest sent Zenodo and arXiv DOIs to Crossref

Both registrars are out of Crossref's index. Every \`10.5281/...\` (Zenodo) and \`10.48550/arxiv...\` (arXiv) DOI 404'd. Visible in the failed run's log — dozens of these:
\`\`\`
HTTP request failed for https://api.crossref.org/works/10.5281/zenodo.1467897: 404
HTTP request failed for https://api.crossref.org/works/10.48550/arxiv.2604.18420: 404
\`\`\`

**Fix:** \`harvest._is_crossref_indexed_doi()\` short-circuits before the call.

## Combined impact

Roughly 5-10 min off harvest's previous 53m runtime, plus much cleaner logs. The \`clean()\` fix has compounding upstream effects (any field that came back as NaN now correctly resolves to empty everywhere).

## Test plan

- [x] \`TestClean\`: NaN float, pandas roundtrip, plus regression guards for \`0\` and \`False\` still rendering (old \`str(v or "")\` silently turned them into \`\"\"\`)
- [x] \`TestHarvest.test_skips_crossref_for_zenodo_and_arxiv_dois\`: only Crossref-prefix DOIs reach the connector
- [x] \`TestHarvest.test_skips_crossref_for_nan_doi_string\`: empty DOI rows make zero Crossref calls
- [x] All 188 tests pass (was 182, +6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)