### PR TITLE
arXiv: lower min_keyword_matches in config + log post-filter count

### DIFF
--- a/alex/pipelines/discovery.py
+++ b/alex/pipelines/discovery.py
@@ -293,6 +293,14 @@ def run() -> None:
         relevant = arxiv.filter_relevant(
             api_papers, queries, arxiv_config.get("min_keyword_matches", 1)
         )
+        # Surface the post-filter count so a misconfigured filter (e.g.
+        # min_keyword_matches=2 on the strict subset matcher) doesn't silently
+        # drop the entire arXiv contribution like it did in run 24909276934.
+        logger.info(
+            "arXiv: %d papers from API -> %d after relevance filter (min_matches=%d)",
+            len(api_papers), len(relevant),
+            arxiv_config.get("min_keyword_matches", 1),
+        )
         for item in relevant:
             add_row(
                 item.get("title", ""),

--- a/config/arxiv_categories.json
+++ b/config/arxiv_categories.json
@@ -1,4 +1,4 @@
 {
   "categories": ["cs.CR", "cs.AI", "cs.CY", "cs.SI", "cs.IR", "cs.NI"],
-  "min_keyword_matches": 2
+  "min_keyword_matches": 1
 }


### PR DESCRIPTION
## Why

Validation run [24909276934](https://github.com/RISEInfoSec/Alex/actions/runs/24909276934) confirmed PR #50's arXiv API switch *works* (1289 papers fetched, log line: \`arXiv API: 1289 unique papers across 6 categories\`) but **zero rows landed in the corpus**.

PR #50 lowered the code default for \`filter_relevant()\` to \`min_matches=1\`, but I missed the config override in \`config/arxiv_categories.json\` which was still pinned at 2. The strict-subset filter requires *both* full query word-sets to be present — empirically that drops effectively everything from arXiv content.

## Fix

- \`config/arxiv_categories.json\`: \`min_keyword_matches\` 2 → 1, matching PR #50's code default and the manual measurement (cs.CR alone yields ~13 relevant papers per 7-day window at \`min_matches=1\`).
- \`discovery.py\`: log \`arXiv: N papers from API -> M after relevance filter (min_matches=K)\` so a silent drop-to-zero never recurs without a visible signal.

## Scope

Two-line config + one log line. No new behaviour beyond what PR #50 promised. The next pipeline run should show ~30-50 arXiv rows added (per the manual experiment that surfaced ~21 across all 6 categories at \`min_matches=1\`).

## Out of scope (filed separately)

- #53 — citation_chain parallelism (29m → ~5m projected)
- #54 — harvest parallelism (50m → ~10m projected)
- Filter quality improvement (current word-set subset matcher is loose for short queries / strict for whole-phrase queries; deserves its own design pass)

## Test plan

- [x] All 188 tests still pass
- [ ] Next pipeline run logs the new line and arXiv count is non-zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)