### PR TITLE
quality_gate: lower auto_include_threshold 75 → 60 (#31)

### DIFF
--- a/config/quality_weights.json
+++ b/config/quality_weights.json
@@ -3,7 +3,7 @@
   "citations": 0.40,
   "relevance": 0.25,
   "institution_bonus": 10.0,
-  "auto_include_threshold": 75.0,
+  "auto_include_threshold": 60.0,
   "review_threshold": 45.0,
   "preprint_auto_include_threshold": 35.0,
   "preprint_review_threshold": 20.0,


### PR DESCRIPTION
Closes #31.

## Why now

Issue #31's blockers are all closed:
- **#28** — venue whitelist expanded (23 major security/cryptography conferences added)
- **#29** — \`usage_score\` metric removed from quality gate (was returning 0 for all papers)
- **#30** — \`relevance_score\` refactored to keyword-based matching after harvest enriches abstracts

The original issue explicitly said *not* to lower the threshold until those landed. They have, and we now have validation-run data to recalibrate against.

## Data from validation run 24909276934

7,106 papers scored:

| Tier | All papers | 2025-2026 only |
|---|---|---|
| Auto-include | 47 (older classics) | **0** |
| Human review | 403 | 86 |
| Reject | 6,656 | 6,149 |

**Max total_quality_score for any 2026 paper: 63.75.** The 75 threshold is structurally unreachable for recent papers — a paper would need a top-tier whitelisted venue AND meaningful citation count, but recent papers have neither (citations accrue over 1-3 years).

## Fix

Single-line config change: \`auto_include_threshold\` 75 → 60.

At 60, a recent paper can auto-include if it has:
- Whitelisted venue + decent relevance (\`1.0×35 + 0×40 + ~0.8×25 = 55\` → not quite, needs some citations or extra)
- OR whitelisted venue + strong relevance + a few citations
- OR institution bonus (10) + good relevance + citation signal

Threshold below the current max-2026 of 63.75 means our top recent papers can clear, while still gating the long tail of weakly-sourced material.

Other thresholds unchanged:
- \`review_threshold: 45\` — papers 45-59 still flagged for human review
- \`preprint_auto_include_threshold: 35\` — preprints (arXiv) on separate ladder
- \`preprint_review_threshold: 20\` — preprint review tier unchanged

## Test plan

- [x] All 192 existing tests pass (test fixtures use their own threshold values inline, not the production config)
- [ ] Next pipeline run will be the first auto-include of recent papers (combined with PR #55's arxiv fix landing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)