### PR TITLE
harvest: parallelise across candidates (50m → ~10m projected)

### DIFF
--- a/alex/pipelines/harvest.py
+++ b/alex/pipelines/harvest.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 import logging
 import os
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
 import pandas as pd
 from alex.utils.io import load_df, save_df, root_file, validate_columns
 from alex.utils.http import HttpClient
@@ -16,12 +18,77 @@ logger = logging.getLogger(__name__)
 # connectors for them elsewhere.
 _NON_CROSSREF_DOI_PREFIXES = ("10.5281/", "10.48550/arxiv")
 
+# Per-candidate parallelism. Same constraint as discovery (#46) and
+# citation_chain (#56): parallelism is *across candidates*, never within
+# one candidate's connector calls. Each thread does serial Crossref ->
+# OpenAlex -> S2 work for one row; the cumulative request rate to any
+# single source is bounded by HttpClient's polite delay (`time.sleep(0.5)`
+# in finally) firing inside each thread independently. Eight workers
+# amortises latency without surprising upstreams with bursty load.
+HARVEST_WORKERS = 8
+
 
 def _is_crossref_indexed_doi(doi: str) -> bool:
     if not doi:
         return False
     lo = doi.lower()
     return not any(lo.startswith(p) for p in _NON_CROSSREF_DOI_PREFIXES)
+
+
+def _harvest_one(
+    client: HttpClient,
+    row: dict | pd.Series,
+    mailto: str,
+    enable_s2: bool,
+    s2_key: str,
+) -> dict[str, Any]:
+    """Resolve one candidate's metadata via Crossref → OpenAlex → S2 fallback.
+
+    Each connector is consulted serially within this thread. Returns a dict
+    with the original row fields overlaid by whatever the upstreams provided.
+    """
+    title = clean(row.get("title"))
+    doi = clean(row.get("doi"))
+    best = dict(row)
+
+    if _is_crossref_indexed_doi(doi):
+        cr = crossref.get_by_doi(client, doi)
+        if cr:
+            best["doi"] = clean(cr.get("DOI", doi))
+            best["venue"] = crossref.venue(cr)
+            authors = "; ".join(
+                f"{a.get('given','')} {a.get('family','')}".strip()
+                for a in (cr.get("author") or [])
+            )
+            best["authors"] = authors or best.get("authors", "")
+            best["abstract"] = crossref.abstract(cr) or best.get("abstract", "")
+            best["source_url"] = clean(cr.get("URL", best.get("source_url", "")))
+            best["harvest_source"] = "Crossref DOI"
+
+    if not best.get("abstract"):
+        oa = openalex.search(client, title, mailto, per_page=1)
+        if oa:
+            work = oa[0]
+            best["doi"] = clean(openalex.doi(work)) or best.get("doi", "")
+            best["venue"] = openalex.venue_name(work) or best.get("venue", "")
+            best["source_url"] = openalex.landing_url(work) or best.get("source_url", "")
+            best["citation_count"] = work.get("cited_by_count", best.get("citation_count", 0))
+            best["reference_count"] = len(work.get("referenced_works") or [])
+            best["harvest_source"] = best.get("harvest_source", "OpenAlex search")
+
+    if enable_s2 and not best.get("abstract"):
+        ss = semantic_scholar.search(client, title, api_key=s2_key, limit=1)
+        if ss:
+            item = ss[0]
+            best["abstract"] = clean(item.get("abstract", "")) or best.get("abstract", "")
+            best["venue"] = clean(item.get("venue", "")) or best.get("venue", "")
+            best["citation_count"] = item.get("citationCount", best.get("citation_count", 0))
+            best["source_url"] = clean(item.get("url", "")) or best.get("source_url", "")
+            ext = item.get("externalIds") or {}
+            best["doi"] = clean(ext.get("DOI", "")) or best.get("doi", "")
+            best["harvest_source"] = best.get("harvest_source", "Semantic Scholar search")
+
+    return best
 
 
 def run() -> None:
@@ -50,51 +117,24 @@ def run() -> None:
         enable_s2 = False
 
     client = HttpClient(mailto=os.getenv("HARVEST_MAILTO", ""))
-    harvested = []
+    mailto = os.getenv("HARVEST_MAILTO", "")
 
-    for _, row in df.iterrows():
-        title = clean(row.get("title"))
-        doi = clean(row.get("doi"))
-        best = dict(row)
-
-        if _is_crossref_indexed_doi(doi):
-            cr = crossref.get_by_doi(client, doi)
-            if cr:
-                best["doi"] = clean(cr.get("DOI", doi))
-                best["venue"] = crossref.venue(cr)
-                authors = "; ".join(
-                    f"{a.get('given','')} {a.get('family','')}".strip()
-                    for a in (cr.get("author") or [])
-                )
-                best["authors"] = authors or best.get("authors", "")
-                best["abstract"] = crossref.abstract(cr) or best.get("abstract", "")
-                best["source_url"] = clean(cr.get("URL", best.get("source_url", "")))
-                best["harvest_source"] = "Crossref DOI"
-
-        if not best.get("abstract"):
-            oa = openalex.search(client, title, os.getenv("HARVEST_MAILTO", ""), per_page=1)
-            if oa:
-                work = oa[0]
-                best["doi"] = clean(openalex.doi(work)) or best.get("doi", "")
-                best["venue"] = openalex.venue_name(work) or best.get("venue", "")
-                best["source_url"] = openalex.landing_url(work) or best.get("source_url", "")
-                best["citation_count"] = work.get("cited_by_count", best.get("citation_count", 0))
-                best["reference_count"] = len(work.get("referenced_works") or [])
-                best["harvest_source"] = best.get("harvest_source", "OpenAlex search")
-
-        if enable_s2 and not best.get("abstract"):
-            ss = semantic_scholar.search(client, title, api_key=s2_key, limit=1)
-            if ss:
-                item = ss[0]
-                best["abstract"] = clean(item.get("abstract", "")) or best.get("abstract", "")
-                best["venue"] = clean(item.get("venue", "")) or best.get("venue", "")
-                best["citation_count"] = item.get("citationCount", best.get("citation_count", 0))
-                best["source_url"] = clean(item.get("url", "")) or best.get("source_url", "")
-                ext = item.get("externalIds") or {}
-                best["doi"] = clean(ext.get("DOI", "")) or best.get("doi", "")
-                best["harvest_source"] = best.get("harvest_source", "Semantic Scholar search")
-
-        harvested.append(best)
+    # Materialise rows up-front so we can submit them in input order and
+    # collect results in the same order — preserves output stability.
+    rows = [row for _, row in df.iterrows()]
+    with ThreadPoolExecutor(max_workers=HARVEST_WORKERS) as ex:
+        futures = [
+            ex.submit(_harvest_one, client, row, mailto, enable_s2, s2_key)
+            for row in rows
+        ]
+        harvested = []
+        for fut in futures:
+            try:
+                harvested.append(fut.result())
+            except Exception as exc:
+                # One bad row shouldn't sink the whole stage; drop it with a
+                # warning so the surviving rows still publish.
+                logger.warning("Harvest failed for one candidate: %s", exc)
 
     save_df(output_path, pd.DataFrame(harvested))
     print(f"Harvested {len(harvested)} accepted candidates")

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -752,6 +752,92 @@ class TestHarvest:
         cr_mock.assert_not_called()
 
 
+class TestHarvestParallelism:
+    """Per-candidate parallelism via ThreadPoolExecutor."""
+
+    def _accepted_csv(self, tmp_path, n=3):
+        rows = [{
+            "title": f"Paper {i}", "authors": "", "year": "2024", "venue": "",
+            "doi": f"10.1145/p{i}", "abstract": "", "source_url": "",
+            "citation_count": 0, "reference_count": 0,
+        } for i in range(n)]
+        (tmp_path / "data").mkdir(parents=True, exist_ok=True)
+        pd.DataFrame(rows).to_csv(tmp_path / "data" / "accepted_candidates.csv", index=False)
+
+    def test_candidates_run_in_parallel_thread_pool(self, tmp_path):
+        # N rows -> N submissions to the executor. Mirrors the per-query
+        # parallelism test in TestDiscoveryConnectorGating.
+        self._accepted_csv(tmp_path, n=3)
+
+        from concurrent.futures import ThreadPoolExecutor
+        original_submit = ThreadPoolExecutor.submit
+        submitted = []
+
+        def tracking_submit(self, fn, *args, **kwargs):
+            submitted.append(fn)
+            return original_submit(self, fn, *args, **kwargs)
+
+        with patch("alex.utils.io.ROOT", tmp_path), \
+             patch("alex.utils.io.DATA_DIR", tmp_path / "data"), \
+             patch("alex.utils.io.CONFIG_DIR", tmp_path / "config"), \
+             patch("alex.pipelines.harvest.connector_config.load", return_value={}), \
+             patch("alex.connectors.crossref.get_by_doi", return_value=None), \
+             patch("alex.connectors.openalex.search", return_value=[]), \
+             patch("alex.pipelines.harvest.HttpClient"), \
+             patch.object(ThreadPoolExecutor, "submit", tracking_submit):
+            from alex.pipelines import harvest
+            harvest.run()
+
+        assert len(submitted) == 3
+
+    def test_output_order_matches_input_order(self, tmp_path):
+        # Even with parallel execution, output rows must appear in the same
+        # order as input rows — collecting futures by submission order
+        # preserves this contract.
+        self._accepted_csv(tmp_path, n=5)
+
+        with patch("alex.utils.io.ROOT", tmp_path), \
+             patch("alex.utils.io.DATA_DIR", tmp_path / "data"), \
+             patch("alex.utils.io.CONFIG_DIR", tmp_path / "config"), \
+             patch("alex.pipelines.harvest.connector_config.load", return_value={}), \
+             patch("alex.connectors.crossref.get_by_doi", return_value=None), \
+             patch("alex.connectors.openalex.search", return_value=[]), \
+             patch("alex.pipelines.harvest.HttpClient"):
+            from alex.pipelines import harvest
+            harvest.run()
+
+        out = pd.read_csv(tmp_path / "data" / "accepted_harvested.csv")
+        # Input was Paper 0, 1, 2, 3, 4 — output must keep that order.
+        assert list(out["title"]) == [f"Paper {i}" for i in range(5)]
+
+    def test_per_row_failure_drops_one_row_does_not_sink_stage(self, tmp_path):
+        # If _harvest_one raises for one row, the other rows must still
+        # land in the output. Surfaced via patching the per-row helper.
+        self._accepted_csv(tmp_path, n=3)
+
+        from alex.pipelines import harvest as harvest_mod
+        real_harvest_one = harvest_mod._harvest_one
+
+        def flaky_harvest_one(client, row, mailto, enable_s2, s2_key):
+            if row.get("title") == "Paper 1":
+                raise RuntimeError("simulated transient failure")
+            return real_harvest_one(client, row, mailto, enable_s2, s2_key)
+
+        with patch("alex.utils.io.ROOT", tmp_path), \
+             patch("alex.utils.io.DATA_DIR", tmp_path / "data"), \
+             patch("alex.utils.io.CONFIG_DIR", tmp_path / "config"), \
+             patch("alex.pipelines.harvest.connector_config.load", return_value={}), \
+             patch("alex.connectors.crossref.get_by_doi", return_value=None), \
+             patch("alex.connectors.openalex.search", return_value=[]), \
+             patch("alex.pipelines.harvest.HttpClient"), \
+             patch("alex.pipelines.harvest._harvest_one", side_effect=flaky_harvest_one):
+            harvest_mod.run()
+
+        out = pd.read_csv(tmp_path / "data" / "accepted_harvested.csv")
+        # 3 input - 1 failed = 2 output rows; the survivors keep their order.
+        assert list(out["title"]) == ["Paper 0", "Paper 2"]
+
+
 class TestDiscoveryAbstractEnrichment:
     def test_enriches_row_missing_abstract_with_doi(self):
         from alex.pipelines.discovery import _enrich_missing_abstracts


### PR DESCRIPTION
Closes #54.

## Why

Validation run [24909276934](https://github.com/RISEInfoSec/Alex/actions/runs/24909276934) measured harvest at **49m59s** — second longest stage (after citation_chain, now fixed by PR #56). The remaining cost is ~468 candidates × ~2.5 connector calls × ~4s each, all serial.

## What

### 1. Per-row work extracted to a pure helper
\`_harvest_one(client, row, mailto, enable_s2, s2_key) -> dict\` returns the original row overlaid with whatever Crossref/OpenAlex/S2 provided. Pure w.r.t. the input row, no shared mutable state — safe to call from multiple threads.

### 2. ThreadPoolExecutor (\`HARVEST_WORKERS=8\`)
Same pattern + same constraint as discovery (PR #46) and citation_chain (PR #56):

- **Parallelism across candidates only.** Each thread does serial Crossref → OpenAlex → S2 work for one row.
- HttpClient's polite delay (\`time.sleep(0.5)\` in finally) keeps per-source rate limiting intact even when all 8 threads are active.
- We never issue concurrent requests *to the same upstream* within one candidate's harvest path.

### 3. Output ordering preserved
\`[fut.result() for fut in futures]\` collects in submission order, so the output CSV row order matches input even when threads finish out of order.

### 4. Per-row failure isolation
If \`_harvest_one\` raises for one row, that row is dropped with a warning but the surviving rows still land in the output. One bad candidate doesn't sink the stage.

## Expected impact

\`50m / 8 ≈ 6m\` plus thread-pool overhead. Conservative target from #54: **<15m**.

## Test plan

- [x] \`test_candidates_run_in_parallel_thread_pool\` — N rows → N submissions
- [x] \`test_output_order_matches_input_order\` — output preserves input order under parallelism
- [x] \`test_per_row_failure_drops_one_row_does_not_sink_stage\` — exception isolation works
- [x] All existing harvest tests pass (config gating, S2 skip, Crossref-prefix filter, NaN handling) — refactor is purely structural
- [x] Suite: 192 → 195 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)