### PR TITLE
openalex.cited_by_api_url: construct URL from work id when missing

### DIFF
--- a/alex/connectors/openalex.py
+++ b/alex/connectors/openalex.py
@@ -105,7 +105,21 @@ def references(work: dict[str, Any]) -> list[str]:
     return work.get("referenced_works") or []
 
 def cited_by_api_url(work: dict[str, Any]) -> str:
-    return clean(work.get("cited_by_api_url"))
+    """Build the OpenAlex `cites:WORK_ID` filter URL for one work.
+
+    OpenAlex no longer returns `cited_by_api_url` as a top-level field on
+    /works search responses (issue #59). Construct it from the work's
+    canonical `id` when the explicit field is absent. The constructed URL
+    matches the form OpenAlex itself produces, so `fetch_cited_by` works
+    against either path interchangeably.
+    """
+    explicit = clean(work.get("cited_by_api_url"))
+    if explicit:
+        return explicit
+    work_id = clean(work.get("id", "")).replace("https://openalex.org/", "")
+    if not work_id:
+        return ""
+    return f"https://api.openalex.org/works?filter=cites:{work_id}"
 
 def fetch_cited_by(client: HttpClient, cited_by_url: str) -> list[dict[str, Any]]:
     data = client.get_json(cited_by_url)

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -40,6 +40,27 @@ class TestOpenAlexAccessors:
         work = {"cited_by_api_url": "https://api.openalex.org/works?filter=cites:W123"}
         assert openalex.cited_by_api_url(work) == "https://api.openalex.org/works?filter=cites:W123"
 
+    def test_cited_by_api_url_constructed_from_id_when_field_missing(self):
+        # Issue #59: OpenAlex no longer returns `cited_by_api_url` as a
+        # top-level field on /works search responses, so we construct the
+        # URL from the work's canonical id instead. Without this, every
+        # citation_chain run silently produced 0 OpenAlex chains.
+        work = {"id": "https://openalex.org/W2752617332"}
+        assert openalex.cited_by_api_url(work) == "https://api.openalex.org/works?filter=cites:W2752617332"
+
+    def test_cited_by_api_url_explicit_field_wins_when_present(self):
+        # If OpenAlex starts returning the explicit field again, prefer it
+        # over the constructed form (the explicit URL may include params
+        # we'd otherwise miss).
+        work = {
+            "id": "https://openalex.org/W123",
+            "cited_by_api_url": "https://api.openalex.org/works?filter=cites:W999&extra=1",
+        }
+        assert openalex.cited_by_api_url(work) == "https://api.openalex.org/works?filter=cites:W999&extra=1"
+
+    def test_cited_by_api_url_empty_when_no_id_or_field(self):
+        assert openalex.cited_by_api_url({}) == ""
+
     def test_references(self):
         work = {"referenced_works": ["W1", "W2"]}
         assert openalex.references(work) == ["W1", "W2"]


### PR DESCRIPTION
Closes #59.

## TL;DR

OpenAlex stopped returning \`cited_by_api_url\` as a top-level field on /works search responses. Our accessor was returning empty for every result — including works with 70k+ citations — and citation_chain's forward-chaining loop was silently skipping every work. **Zero \`OpenAlex citation chain\` rows have ever entered the corpus.** Fix is two lines: construct the URL from \`work["id"]\` when the explicit field is absent.

## Discovery

While inspecting the in-flight validation run [24917841959](https://github.com/RISEInfoSec/Alex/actions/runs/24917841959), the citation_chain commit landed with \`1131 insertions(+), 1131 deletions(-)\` — same row count, just reordered. **Zero net new candidates added.**

Live probe of the top seed:

\`\`\`
work id: https://openalex.org/W2752617332
cited_by_api_url: None        ← empty
cited_by_count: 69887         ← seventy thousand citations
\`\`\`

Constructed URL works fine:
\`\`\`
https://api.openalex.org/works?filter=cites:W2752617332&per-page=5
→ "Corporate financing and investment decisions when firms have information that…"
→ "Separation of Ownership and Control"
→ "Law and Finance"
\`\`\`

## Why we missed it

- \`OpenAlex citation chain\` rows in the corpus: **0** across every run since project start.
- The 56 \`Semantic Scholar citation chain\` rows came from when S2 was active; OpenAlex forward chaining has never contributed.
- Tests provided \`cited_by_api_url\` as a non-empty string in mock work dicts, so the test path didn't exercise the missing-field case.

## Cost

Citation_chain burned ~30-44 min/run pre-PR #56 (now 9m48s post-parallelism) doing OpenAlex searches whose results were always discarded. Every run for the entire project history. PR #56 made the broken stage fast; **this PR makes it actually do work.**

## Fix

\`\`\`python
def cited_by_api_url(work):
    explicit = clean(work.get("cited_by_api_url"))
    if explicit:
        return explicit
    work_id = clean(work.get("id", "")).replace("https://openalex.org/", "")
    if not work_id:
        return ""
    return f"https://api.openalex.org/works?filter=cites:{work_id}"
\`\`\`

Explicit field still wins if OpenAlex starts returning it again (it may carry extra params we'd otherwise miss).

## Test plan

- [x] \`test_cited_by_api_url_constructed_from_id_when_field_missing\` — the bug case
- [x] \`test_cited_by_api_url_explicit_field_wins_when_present\` — back-compat
- [x] \`test_cited_by_api_url_empty_when_no_id_or_field\` — edge case
- [x] Existing test (explicit field present) unchanged
- [x] Suite: 195 → 198 passing
- [ ] Next pipeline run should add **non-zero** \`OpenAlex citation chain\` rows (canary metric: tens to hundreds, given top-100 highly-cited seeds × 5 cited-by per work × dedup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)