### PR TITLE
citation_chain: trim OpenAlex cited_by payloads via per-page + select

### DIFF
--- a/alex/connectors/openalex.py
+++ b/alex/connectors/openalex.py
@@ -121,8 +121,27 @@ def cited_by_api_url(work: dict[str, Any]) -> str:
         return ""
     return f"https://api.openalex.org/works?filter=cites:{work_id}"
 
-def fetch_cited_by(client: HttpClient, cited_by_url: str) -> list[dict[str, Any]]:
-    data = client.get_json(cited_by_url)
+def fetch_cited_by(
+    client: HttpClient,
+    cited_by_url: str,
+    per_page: int | None = None,
+    select: str = "",
+) -> list[dict[str, Any]]:
+    """Fetch works that cite the given OpenAlex work.
+
+    `per_page` lets the caller bound the response size — without it OpenAlex
+    serves the default 25 results. Citation chain only ever uses ~5, so the
+    other 20 are pure transfer waste on heavy-seed queries (papers cited
+    >10k times return slowly even when paginated). `select` is a comma-
+    separated field list that further trims OpenAlex's serialisation
+    cost; pass only what the caller reads from each result.
+    """
+    params: dict[str, Any] = {}
+    if per_page is not None:
+        params["per-page"] = per_page
+    if select:
+        params["select"] = select
+    data = client.get_json(cited_by_url, params=params or None)
     return (data or {}).get("results", [])
 
 

--- a/alex/pipelines/citation_chain.py
+++ b/alex/pipelines/citation_chain.py
@@ -33,6 +33,13 @@ CITATION_CHAIN_WORKERS = 8
 DEFAULT_OA_SEARCH_LIMIT = 3
 DEFAULT_OA_CITED_BY_LIMIT = 5
 
+# Fields read off each cited-by result below. Passed to OpenAlex via the
+# `select` query param so heavy-seed queries (papers cited >10k times)
+# don't pay the default ~5KB-per-result serialisation cost on fields we
+# discard. Keep this list in sync with the dict-construction below: any
+# field this list omits will read as None/empty from the response.
+_CITED_BY_FIELDS = "id,title,authorships,publication_year,primary_location,ids,cited_by_count,referenced_works"
+
 # Same shape for S2 backward-chaining. These are only consulted when S2 is
 # enabled and keyed; the S2 gate from PR #48 short-circuits both calls.
 DEFAULT_SS_SEARCH_LIMIT = 3
@@ -168,7 +175,15 @@ def _chain_one_candidate(
         cited_by_url = openalex.cited_by_api_url(work)
         if not cited_by_url:
             continue
-        for cited in openalex.fetch_cited_by(client, cited_by_url)[:oa_cited_by_limit]:
+        # Both gates: per_page asks OpenAlex for at most N (the perf win —
+        # see _CITED_BY_FIELDS comment), and the [:N] slice enforces the
+        # limit client-side so a mock or a future OpenAlex contract change
+        # that returns more can't widen the chain. Cheap belt-and-suspenders.
+        for cited in openalex.fetch_cited_by(
+            client, cited_by_url,
+            per_page=oa_cited_by_limit,
+            select=_CITED_BY_FIELDS,
+        )[:oa_cited_by_limit]:
             ct = clean(cited.get("title"))
             if not ct:
                 continue

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -138,6 +138,42 @@ class TestOpenAlexSearch:
         assert client.get_json.call_count == 2  # capped
 
 
+class TestOpenAlexFetchCitedBy:
+    def test_no_params_passed_when_kwargs_omitted(self):
+        # Back-compat: existing callers (none today, but the signature
+        # changed) get unchanged behaviour — no per-page or select forces
+        # the OpenAlex default of 25 results with full fields.
+        from unittest.mock import MagicMock
+        client = MagicMock()
+        client.get_json.return_value = {"results": [{"title": "A"}]}
+        result = openalex.fetch_cited_by(client, "https://api.openalex.org/works?filter=cites:W123")
+        assert result == [{"title": "A"}]
+        # params=None when no kwargs supplied (cache key stays compatible
+        # with whatever existing entries exist for the bare URL).
+        assert client.get_json.call_args.kwargs.get("params") is None
+
+    def test_per_page_and_select_reach_openalex(self):
+        # Issue #62 perf fix: fetch_cited_by must propagate per_page and
+        # select to OpenAlex via query params, not just slice the response
+        # client-side. Without this, a heavy seed (paper cited >10k times)
+        # serves a 25-result page with full fields per result every call —
+        # OpenAlex serialisation + transfer dominates and citation_chain
+        # times out the runner.
+        from unittest.mock import MagicMock
+        client = MagicMock()
+        client.get_json.return_value = {"results": [{"id": "W1"}]}
+        openalex.fetch_cited_by(
+            client,
+            "https://api.openalex.org/works?filter=cites:W123",
+            per_page=5,
+            select="id,title,cited_by_count",
+        )
+        params = client.get_json.call_args.kwargs.get("params")
+        assert params is not None
+        assert params["per-page"] == 5
+        assert params["select"] == "id,title,cited_by_count"
+
+
 class TestOpenAlexBatchByDoi:
     def test_returns_empty_for_empty_input(self):
         from unittest.mock import MagicMock


### PR DESCRIPTION
## Summary

The chain stage's recent slowdown (6-7 min Apr 23 → 28 min Apr 25 → 66 min Apr 27) isn't actually a code regression — it's the side-effect of #59's cited_by_api_url fix landing in 2966a6f. Before that, `cited_by_api_url` returned empty for every work and the chain short-circuited as a silent no-op. Once chains actually started running, each `fetch_cited_by` call fetches the OpenAlex default of 25 results with full fields, and on heavy seeds (papers cited 10k+ times) OpenAlex's own query latency dominates.

Two upstream-side trims to `fetch_cited_by`:

- `per_page=5` (was OpenAlex default 25) — citation_chain only ever uses 5 anyway. Cuts response size ~5×.
- `select=id,title,authorships,publication_year,primary_location,ids,cited_by_count,referenced_works` — exactly the fields citation_chain reads. Drops `abstract_inverted_index` (the largest per-result field) and other unused properties. OpenAlex's serialisation savings stack with the per_page reduction.

Defence-in-depth: the `[:oa_cited_by_limit]` slice client-side stays so a mock or a future OpenAlex contract change that returns more can't widen the chain. The existing limit-cap test continues to assert this invariant.

Closes the citation_chain piece of #62. The pipeline split (#63) and classify parallelisation (#64) shipped earlier.

## Test plan

- [x] 222 tests passing locally (was 220 + 2 new `TestOpenAlexFetchCitedBy` cases).
- [x] `test_per_page_and_select_reach_openalex` asserts the new params actually land in OpenAlex GET params — without this the perf fix would silently regress to the 25-result default.
- [x] `test_no_params_passed_when_kwargs_omitted` keeps the bare URL form working (no current caller relies on it, but signature back-compat).
- [x] Existing `test_openalex_cited_by_limit_caps_results_per_work` still passes — client-side slice intact.
- [ ] Run citation_chain workflow on next pipeline run; observe stage duration vs Apr 27's 66 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)